### PR TITLE
Fix project ID handling in validation and review tab refresh

### DIFF
--- a/database.py
+++ b/database.py
@@ -505,10 +505,11 @@ def get_control_file(project_id):
             SELECT p.project_name, cm.control_file_name
             FROM ProjectManagement.dbo.tblControlModels cm
             JOIN ProjectManagement.dbo.projects p ON cm.project_id = p.project_id
-        """)
+            WHERE cm.project_id = ?
+        """, (project_id,))
 
         row = cursor.fetchone()
-        return row[0] if row else None
+        return row[1] if row else None
     except Exception as e:
         print(f"❌ Error fetching control file: {e}")
         return None

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -39,9 +39,11 @@ def open_revizto_csharp_app():
         messagebox.showerror("Error", f"EXE not found at: {exe_path}")
 
 def build_review_tab(tab, status_var):
+    global cmb_projects_ref
     # --- Project & Cycle Selection ---
     projects = [f"{p[0]} - {p[1]}" for p in get_projects()]
     _, cmb_projects = create_labeled_combobox(tab, "Project:", projects)
+    cmb_projects_ref = cmb_projects
     _, cmb_cycles = create_labeled_combobox(tab, "Cycle:", [])
 
     def load_cycles(event=None):

--- a/ui/tab_validation.py
+++ b/ui/tab_validation.py
@@ -103,7 +103,7 @@ def build_validation_tab(tab, status_var):
             messagebox.showerror("Error", "Select a valid naming_conventions.json file")
             return
 
-        project_files = get_project_health_files(project_name)
+        project_files = get_project_health_files(project_id)
         if not project_files:
             messagebox.showinfo("No Files", "No project files found")
             return


### PR DESCRIPTION
## Summary
- correct parameter for project health file retrieval in the validation tab
- filter control file query by project ID and return filename
- assign review tab combobox reference so other tabs can refresh it

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6847b26957ac832ea2f1ad63da610294