### PR TITLE
Support ZIP uploads for ACC data

### DIFF
--- a/acc_handler.py
+++ b/acc_handler.py
@@ -6,6 +6,9 @@ import datetime
 import re
 import sqlparse
 import time
+import zipfile
+import tempfile
+import shutil
 from database import get_acc_folder_path, log_acc_import
 
 UUID_REGEX = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
@@ -177,7 +180,19 @@ def run_merge_script(cursor, conn, script_filename, merge_dir="sql"):
 
 def import_acc_data(folder_path, server, db, user, pwd, merge_dir="sql"):
     summary = []
-    with open(LOG_FILE, "w"): pass  # clear log file
+    with open(LOG_FILE, "w"):  # clear log file
+        pass
+
+    temp_dir = None
+    if folder_path.lower().endswith(".zip") and os.path.isfile(folder_path):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            with zipfile.ZipFile(folder_path, "r") as zip_ref:
+                zip_ref.extractall(temp_dir)
+            folder_path = temp_dir
+        except Exception as exc:
+            shutil.rmtree(temp_dir)
+            raise exc
 
     conn = connect_to_db(server, db, user, pwd)
     cursor = conn.cursor()
@@ -207,6 +222,8 @@ def import_acc_data(folder_path, server, db, user, pwd, merge_dir="sql"):
 
     cursor.close()
     conn.close()
+    if temp_dir:
+        shutil.rmtree(temp_dir)
     return summary
 
 
@@ -220,6 +237,12 @@ def run_acc_import(project_dropdown, acc_folder_entry, acc_summary_listbox):
 
     if not os.path.exists(folder_path):
         return False, "Folder path is invalid."
+
+    if os.path.isfile(folder_path):
+        if not folder_path.lower().endswith(".zip"):
+            return False, "Selected file must be a .zip archive."
+    elif not os.path.isdir(folder_path):
+        return False, "Select a valid folder or ZIP file."
 
     summary = import_acc_data(folder_path, "P-NB-USER-028\\SQLEXPRESS", "acc_data_schema", "admin02", "1234")
 

--- a/ui/tab_data_imports.py
+++ b/ui/tab_data_imports.py
@@ -145,19 +145,27 @@ def build_data_imports_tab(tab, status_var):
 
     # --- ACC CSV Import Section ---
     ttk.Label(tab, text="ACC Export CSV Import", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)
-    _, entry_acc_folder = create_labeled_entry(tab, "ACC CSV Folder:")
-    CreateToolTip(entry_acc_folder, "Select the folder containing weekly ACC CSV exports")
+    _, entry_acc_folder = create_labeled_entry(tab, "ACC CSV Folder/ZIP:")
+    CreateToolTip(entry_acc_folder, "Select the folder containing weekly ACC CSV exports or a ZIP archive")
 
     def browse_acc_folder():
-        path = filedialog.askdirectory()
+        path = filedialog.askopenfilename(filetypes=[("ZIP files", "*.zip")])
         if path:
             entry_acc_folder.delete(0, tk.END)
             entry_acc_folder.insert(0, path)
+        else:
+            path = filedialog.askdirectory()
+            if path:
+                entry_acc_folder.delete(0, tk.END)
+                entry_acc_folder.insert(0, path)
 
     def import_acc_csv():
         folder = entry_acc_folder.get().strip()
-        if not folder or not os.path.isdir(folder):
-            messagebox.showerror("Error", "Select a valid folder")
+        if not folder or not (
+            os.path.isdir(folder)
+            or (os.path.isfile(folder) and folder.lower().endswith(".zip"))
+        ):
+            messagebox.showerror("Error", "Select a valid folder or ZIP file")
             return
         success, msg = run_acc_import(cmb_projects, entry_acc_folder, log_list)
         if success:


### PR DESCRIPTION
## Summary
- support ZIP extraction in `import_acc_data`
- validate ZIP selection in `run_acc_import`
- allow UI browsing for ZIP archives and document new option

## Testing
- `python -m py_compile acc_handler.py ui/tab_data_imports.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848df977290832e88700cb86f87d4a7