### PR TITLE
Update ACC CSV import button placement

### DIFF
--- a/ui/tab_data_imports.py
+++ b/ui/tab_data_imports.py
@@ -135,40 +135,26 @@ def build_data_imports_tab(tab, status_var):
         save_acc_folder_path(pid, path)
         update_status(status_var, "ACC data export path saved")
 
-    create_horizontal_button_group(tab, [
-        ("Browse", browse_data_export),
-        ("Save Path", save_data_export),
-    ])
-
-    log_list = tk.Listbox(tab, width=80, height=5)
-    log_list.pack(padx=10, pady=5, anchor="w")
-
-    # --- ACC CSV Import Section ---
-    ttk.Label(tab, text="ACC Export CSV Import", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)
-    _, entry_acc_folder = create_labeled_entry(tab, "ACC CSV Folder:")
-    CreateToolTip(entry_acc_folder, "Select the folder containing weekly ACC CSV exports")
-
-    def browse_acc_folder():
-        path = filedialog.askdirectory()
-        if path:
-            entry_acc_folder.delete(0, tk.END)
-            entry_acc_folder.insert(0, path)
-
     def import_acc_csv():
-        folder = entry_acc_folder.get().strip()
+        folder = entry_data_export.get().strip()
         if not folder or not os.path.isdir(folder):
             messagebox.showerror("Error", "Select a valid folder")
             return
-        success, msg = run_acc_import(cmb_projects, entry_acc_folder, log_list)
+        success, msg = run_acc_import(cmb_projects, entry_data_export, log_list)
         if success:
             update_status(status_var, msg)
         else:
             messagebox.showerror("Error", msg)
 
     create_horizontal_button_group(tab, [
-        ("Browse", browse_acc_folder),
+        ("Browse", browse_data_export),
+        ("Save Path", save_data_export),
         ("Import ACC CSVs", import_acc_csv),
     ])
+
+    log_list = tk.Listbox(tab, width=80, height=5)
+    log_list.pack(padx=10, pady=5, anchor="w")
+
 
     # --- Clash CSV Import Section ---
     ttk.Label(tab, text="Clash CSV Import", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)


### PR DESCRIPTION
## Summary
- remove standalone ACC CSV import section
- hook ACC CSV import to existing export folder controls

## Testing
- `python -m py_compile ui/tab_data_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6848e2e2d904832eaa32ffe6d8c2d913