### PR TITLE
Remove unused webview import

### DIFF
--- a/gantt_chart.py
+++ b/gantt_chart.py
@@ -3,7 +3,6 @@ from dash import dcc, html, Input, Output, State
 import plotly.express as px
 import pandas as pd
 import threading
-import webview  # ✅ Opens a separate pop-up
 from database import get_review_schedule
 from review_handler import update_review_date, adjust_future_tasks, delete_review_task
 


### PR DESCRIPTION
## Summary
- clean up `gantt_chart.py` by removing unused `webview` import
- ensure syntax correctness with `py_compile`

## Testing
- `python -m py_compile gantt_chart.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ef286f38832ea6ab50b9e4f68f83