### PR TITLE
Support additional review cycle details

### DIFF
--- a/database.py
+++ b/database.py
@@ -128,13 +128,31 @@ def get_review_schedule(project_id, cycle_id):
     try:
         cursor = conn.cursor()
         
-        cursor.execute("""
-            SELECT rs.schedule_id, rs.review_date, rs.cycle_id, p.project_name
+        cursor.execute(
+            """
+            SELECT rs.schedule_id,
+                   rs.review_date,
+                   rs.cycle_id,
+                   p.project_name,
+                   d.construction_stage,
+                   d.proposed_fee,
+                   d.assigned_users,
+                   d.reviews_per_phase,
+                   d.planned_start_date,
+                   d.planned_completion_date,
+                   d.actual_start_date,
+                   d.actual_completion_date,
+                   d.hold_date,
+                   d.resume_date,
+                   d.new_contract
             FROM ReviewSchedule rs
             JOIN Projects p ON rs.project_id = p.project_id
+            LEFT JOIN ReviewCycleDetails d ON rs.project_id = d.project_id AND rs.cycle_id = d.cycle_id
             WHERE rs.project_id = ? AND rs.cycle_id = ?
             ORDER BY rs.review_date ASC;
-        """, (project_id, cycle_id))
+        """,
+            (project_id, cycle_id),
+        )
 
         result = cursor.fetchall()
 
@@ -147,8 +165,36 @@ def get_review_schedule(project_id, cycle_id):
 
         # ✅ Convert query result into a Pandas DataFrame
         structured_result = [tuple(row) for row in result]
-        df = pd.DataFrame(structured_result, columns=["schedule_id", "review_date", "cycle_id", "project_name"])
-        df["review_date"] = pd.to_datetime(df["review_date"], errors="coerce")  # ✅ Ensure proper date format
+        df = pd.DataFrame(
+            structured_result,
+            columns=[
+                "schedule_id",
+                "review_date",
+                "cycle_id",
+                "project_name",
+                "construction_stage",
+                "proposed_fee",
+                "assigned_users",
+                "reviews_per_phase",
+                "planned_start_date",
+                "planned_completion_date",
+                "actual_start_date",
+                "actual_completion_date",
+                "hold_date",
+                "resume_date",
+                "new_contract",
+            ],
+        )
+        df["review_date"] = pd.to_datetime(df["review_date"], errors="coerce")
+        for col in [
+            "planned_start_date",
+            "planned_completion_date",
+            "actual_start_date",
+            "actual_completion_date",
+            "hold_date",
+            "resume_date",
+        ]:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
 
         project_name = df["project_name"].iloc[0] if not df.empty else "Unknown Project"
         cycle_id = df["cycle_id"].iloc[0] if not df.empty else "Unknown Cycle"
@@ -570,3 +616,132 @@ def update_file_validation_status(file_name, status, reason, regex_used):
             conn.commit()
     except Exception as e:
         print(f"❌ Failed to update validation for {file_name}: {e}")
+
+# ------------------------------------------------------------
+# Review cycle detail functions
+# ------------------------------------------------------------
+
+def insert_review_cycle_details(
+    project_id,
+    cycle_id,
+    construction_stage,
+    proposed_fee,
+    assigned_users,
+    reviews_per_phase,
+    planned_start_date,
+    planned_completion_date,
+    actual_start_date,
+    actual_completion_date,
+    hold_date,
+    resume_date,
+    new_contract,
+):
+    """Insert details for a review cycle."""
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO ReviewCycleDetails (
+                project_id,
+                cycle_id,
+                construction_stage,
+                proposed_fee,
+                assigned_users,
+                reviews_per_phase,
+                planned_start_date,
+                planned_completion_date,
+                actual_start_date,
+                actual_completion_date,
+                hold_date,
+                resume_date,
+                new_contract
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                project_id,
+                cycle_id,
+                construction_stage,
+                proposed_fee,
+                assigned_users,
+                reviews_per_phase,
+                planned_start_date,
+                planned_completion_date,
+                actual_start_date,
+                actual_completion_date,
+                hold_date,
+                resume_date,
+                int(new_contract),
+            ),
+        )
+        conn.commit()
+        return True
+    except Exception as e:
+        print(f"❌ Error inserting review cycle details: {e}")
+        return False
+    finally:
+        conn.close()
+
+def update_review_cycle_details(
+    project_id,
+    cycle_id,
+    construction_stage,
+    proposed_fee,
+    assigned_users,
+    reviews_per_phase,
+    planned_start_date,
+    planned_completion_date,
+    actual_start_date,
+    actual_completion_date,
+    hold_date,
+    resume_date,
+    new_contract,
+):
+    """Update details for a review cycle."""
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE ReviewCycleDetails
+            SET construction_stage = ?,
+                proposed_fee = ?,
+                assigned_users = ?,
+                reviews_per_phase = ?,
+                planned_start_date = ?,
+                planned_completion_date = ?,
+                actual_start_date = ?,
+                actual_completion_date = ?,
+                hold_date = ?,
+                resume_date = ?,
+                new_contract = ?
+            WHERE project_id = ? AND cycle_id = ?;
+            """,
+            (
+                construction_stage,
+                proposed_fee,
+                assigned_users,
+                reviews_per_phase,
+                planned_start_date,
+                planned_completion_date,
+                actual_start_date,
+                actual_completion_date,
+                hold_date,
+                resume_date,
+                int(new_contract),
+                project_id,
+                cycle_id,
+            ),
+        )
+        conn.commit()
+        return True
+    except Exception as e:
+        print(f"❌ Error updating review cycle details: {e}")
+        return False
+    finally:
+        conn.close()
+

--- a/gantt_chart.py
+++ b/gantt_chart.py
@@ -22,11 +22,24 @@ def load_review_schedule(project_id, cycle_id):
         print(f"⚠️ No review schedule data found for Project {project_id}, Cycle {cycle_id}")
         return pd.DataFrame(columns=["schedule_id", "cycle_id", "review_date", "task_name", "end_date"]), [], "", ""
 
-    # ✅ Ensure 'review_date' is correctly converted
-    df['review_date'] = pd.to_datetime(df['review_date'], errors='coerce')
+    # ✅ Ensure dates are correctly converted
+    date_cols = [
+        'review_date',
+        'planned_start_date',
+        'planned_completion_date',
+        'actual_start_date',
+        'actual_completion_date',
+        'hold_date',
+        'resume_date',
+    ]
+    for col in date_cols:
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors='coerce')
 
     # ✅ Print converted dates
-    print(f"🔍 Converted Dates:\n{df[['schedule_id', 'review_date']].head()}")
+    print(
+        f"🔍 Converted Dates:\n{df[['schedule_id', 'review_date', 'planned_start_date', 'actual_start_date']].head()}"
+    )
 
     # ✅ Generate meaningful task names
     df['task_name'] = [f"Review {review_option}-{i+1}" for i in range(len(df))]
@@ -34,7 +47,9 @@ def load_review_schedule(project_id, cycle_id):
     # ✅ Add an end date for each task
     df['end_date'] = df['review_date'] + pd.Timedelta(days=1)
 
-    print(f"✅ Processed Data for Gantt Chart:\n{df[['task_name', 'review_date', 'end_date']]}")  
+    print(
+        f"✅ Processed Data for Gantt Chart:\n{df[['task_name', 'review_date', 'end_date', 'planned_start_date', 'planned_completion_date']]}"
+    )
 
     # ✅ Ensure dropdown options for deletion
     dropdown_options = [{"label": task, "value": schedule_id} for task, schedule_id in zip(df['task_name'], df['schedule_id'])]

--- a/sql/add_review_cycle_details.sql
+++ b/sql/add_review_cycle_details.sql
@@ -1,0 +1,20 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'ReviewCycleDetails')
+BEGIN
+    CREATE TABLE ReviewCycleDetails (
+        project_id INT NOT NULL,
+        cycle_id INT NOT NULL,
+        construction_stage NVARCHAR(100),
+        proposed_fee DECIMAL(18,2),
+        assigned_users NVARCHAR(MAX),
+        reviews_per_phase NVARCHAR(MAX),
+        planned_start_date DATE,
+        planned_completion_date DATE,
+        actual_start_date DATE,
+        actual_completion_date DATE,
+        hold_date DATE,
+        resume_date DATE,
+        new_contract BIT DEFAULT 0,
+        CONSTRAINT PK_ReviewCycleDetails PRIMARY KEY (project_id, cycle_id)
+    );
+END;
+GO

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -80,6 +80,49 @@ def build_review_tab(tab, status_var):
     license_duration_entry = ttk.Entry(tab, width=10)
     license_duration_entry.pack(padx=10, pady=2, anchor="w")
 
+    ttk.Label(tab, text="Construction Stage:").pack(padx=10, anchor="w")
+    stage_entry = ttk.Entry(tab, width=20)
+    stage_entry.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Proposed Fee:").pack(padx=10, anchor="w")
+    fee_entry = ttk.Entry(tab, width=12)
+    fee_entry.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Assigned Users:").pack(padx=10, anchor="w")
+    assigned_users_entry = ttk.Entry(tab, width=30)
+    assigned_users_entry.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Reviews Per Phase:").pack(padx=10, anchor="w")
+    reviews_per_phase_entry = ttk.Entry(tab, width=10)
+    reviews_per_phase_entry.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Planned Start Date:").pack(padx=10, anchor="w")
+    planned_start = DateEntry(tab, width=12)
+    planned_start.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Planned Completion Date:").pack(padx=10, anchor="w")
+    planned_completion = DateEntry(tab, width=12)
+    planned_completion.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Actual Start Date:").pack(padx=10, anchor="w")
+    actual_start = DateEntry(tab, width=12)
+    actual_start.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Actual Completion Date:").pack(padx=10, anchor="w")
+    actual_completion = DateEntry(tab, width=12)
+    actual_completion.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Hold Date:").pack(padx=10, anchor="w")
+    hold_date = DateEntry(tab, width=12)
+    hold_date.pack(padx=10, pady=2, anchor="w")
+
+    ttk.Label(tab, text="Resume Date:").pack(padx=10, anchor="w")
+    resume_date = DateEntry(tab, width=12)
+    resume_date.pack(padx=10, pady=2, anchor="w")
+
+    new_contract_var = tk.BooleanVar()
+    ttk.Checkbutton(tab, text="New Contract", variable=new_contract_var).pack(padx=10, anchor="w")
+
     def submit_schedule():
         submit_review_schedule(
             cmb_projects,
@@ -89,6 +132,17 @@ def build_review_tab(tab, status_var):
             freq_entry,
             license_start_date,
             license_duration_entry,
+            stage_entry,
+            fee_entry,
+            assigned_users_entry,
+            reviews_per_phase_entry,
+            planned_start,
+            planned_completion,
+            actual_start,
+            actual_completion,
+            hold_date,
+            resume_date,
+            new_contract_var,
         )
         update_status(status_var, "Review schedule submitted")
 


### PR DESCRIPTION
## Summary
- extend schema with new `ReviewCycleDetails` table
- collect extra fields in the review tab UI
- save and update these details through `review_handler`
- fetch new columns via `database.get_review_schedule`
- expose data in Gantt chart and add schema SQL script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492470bad4832e8d5d2e9e59285535