### PR TITLE
Add reviewer assignment

### DIFF
--- a/database.py
+++ b/database.py
@@ -570,3 +570,63 @@ def update_file_validation_status(file_name, status, reason, regex_used):
             conn.commit()
     except Exception as e:
         print(f"❌ Failed to update validation for {file_name}: {e}")
+
+
+def get_users_list():
+    """Return a list of (user_id, name) tuples from the users table."""
+    conn = connect_to_db()
+    if conn is None:
+        return []
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT user_id, name FROM users ORDER BY name;")
+        return [(row[0], row[1]) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"❌ Error fetching users: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def get_review_tasks(project_id, cycle_id):
+    """Return review schedule tasks for a project and cycle."""
+    conn = connect_to_db()
+    if conn is None:
+        return []
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT schedule_id, review_date, assigned_to
+            FROM ReviewSchedule
+            WHERE project_id = ? AND cycle_id = ?
+            ORDER BY review_date
+            """,
+            (project_id, cycle_id),
+        )
+        return cursor.fetchall()
+    except Exception as e:
+        print(f"❌ Error fetching review tasks: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def update_review_task_assignee(schedule_id, user_id):
+    """Update the assigned reviewer for a review task."""
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE ReviewSchedule SET assigned_to = ? WHERE schedule_id = ?",
+            (user_id, schedule_id),
+        )
+        conn.commit()
+        return True
+    except Exception as e:
+        print(f"❌ Error updating task assignee: {e}")
+        return False
+    finally:
+        conn.close()

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -16,7 +16,13 @@ from ui.tooltips import CreateToolTip
 
 from review_handler import submit_review_schedule
 from gantt_chart import launch_gantt_chart
-from database import get_projects, get_cycle_ids
+from database import (
+    get_projects,
+    get_cycle_ids,
+    get_users_list,
+    get_review_tasks,
+    update_review_task_assignee,
+)
 
 # Global reference to the project dropdown so other tabs can refresh it
 cmb_projects_ref = None
@@ -96,6 +102,64 @@ def build_review_tab(tab, status_var):
         tab,
         [("Submit Schedule", submit_schedule), ("Launch Gantt Chart", lambda: launch_gantt_chart(None, None))],
     )
+
+    # --- Reviewer Assignment Section ---
+    ttk.Label(tab, text="Reviewer Assignment", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)
+
+    assignment_frame = ttk.Frame(tab)
+    assignment_frame.pack(fill="both", padx=10, pady=5)
+
+    tree_reviews = ttk.Treeview(assignment_frame, columns=("id", "date", "user"), show="headings", height=5)
+    tree_reviews.heading("id", text="ID")
+    tree_reviews.heading("date", text="Review Date")
+    tree_reviews.heading("user", text="Reviewer")
+    tree_reviews.pack(side="left", fill="both", expand=True)
+
+    scroll = ttk.Scrollbar(assignment_frame, orient="vertical", command=tree_reviews.yview)
+    tree_reviews.configure(yscrollcommand=scroll.set)
+    scroll.pack(side="right", fill="y")
+
+    reviewer_var = tk.StringVar()
+    reviewer_dropdown = ttk.Combobox(tab, textvariable=reviewer_var)
+    reviewer_dropdown.pack(padx=10, anchor="w")
+
+    def load_users():
+        users = get_users_list()
+        reviewer_dropdown['values'] = [u[1] for u in users]
+        return {u[1]: u[0] for u in users}
+
+    users_map = load_users()
+
+    def refresh_tasks(event=None):
+        nonlocal users_map
+        users_map = load_users()
+        for item in tree_reviews.get_children():
+            tree_reviews.delete(item)
+        if " - " not in cmb_projects.get() or not cmb_cycles.get():
+            return
+        pid = cmb_projects.get().split(" - ")[0]
+        cid = cmb_cycles.get()
+        rows = get_review_tasks(pid, cid)
+        for sched_id, date, user in rows:
+            tree_reviews.insert("", tk.END, iid=sched_id, values=(sched_id, date, user or ""))
+
+    def assign_reviewer():
+        sel = tree_reviews.focus()
+        if not sel:
+            messagebox.showerror("Error", "Select a review task")
+            return
+        name = reviewer_var.get()
+        if not name or name not in users_map:
+            messagebox.showerror("Error", "Select a reviewer")
+            return
+        if update_review_task_assignee(sel, users_map[name]):
+            refresh_tasks()
+
+    ttk.Button(tab, text="Assign To Selected", command=assign_reviewer).pack(padx=10, pady=2, anchor="w")
+
+    cmb_projects.bind("<<ComboboxSelected>>", lambda e: [load_cycles(), refresh_tasks()])
+    cmb_cycles.bind("<<ComboboxSelected>>", refresh_tasks)
+    refresh_tasks()
 
     # --- Issue Tracking Section ---
     ttk.Label(tab, text="Revizto Issue Synchronisation", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)


### PR DESCRIPTION
## Summary
- extend `database` helper with user and review-task utilities
- expand tasks UI to record cycle IDs and show task list
- expose reviewer assignment table in the Review Management tab

## Testing
- `python -m py_compile tasks_users_ui.py ui/tab_review.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6849259b67ec832ea363bc3058d7f98e