### PR TITLE
Add scrollable frames to UI tabs

### DIFF
--- a/ui/base_layout.py
+++ b/ui/base_layout.py
@@ -2,6 +2,7 @@
 
 import tkinter as tk
 from tkinter import ttk
+from .ui_helpers import create_scrollable_frame
 
 def build_main_ui():
     root = tk.Tk()
@@ -17,15 +18,21 @@ def build_main_ui():
     notebook.pack(fill="both", expand=True)
 
     # Placeholder tabs (content will come from submodules)
-    tab_project = ttk.Frame(notebook)
-    tab_imports = ttk.Frame(notebook)
-    tab_review = ttk.Frame(notebook)
-    tab_validation = ttk.Frame(notebook)
+    tab_project_container = ttk.Frame(notebook)
+    tab_imports_container = ttk.Frame(notebook)
+    tab_review_container = ttk.Frame(notebook)
+    tab_validation_container = ttk.Frame(notebook)
 
-    notebook.add(tab_project, text="Project Setup")
-    notebook.add(tab_imports, text="Data Imports")
-    notebook.add(tab_review, text="Review Management")
-    notebook.add(tab_validation, text="Validation & Results")
+    # Make each tab scrollable and return the inner frame used by builders
+    tab_project = create_scrollable_frame(tab_project_container)
+    tab_imports = create_scrollable_frame(tab_imports_container)
+    tab_review = create_scrollable_frame(tab_review_container)
+    tab_validation = create_scrollable_frame(tab_validation_container)
+
+    notebook.add(tab_project_container, text="Project Setup")
+    notebook.add(tab_imports_container, text="Data Imports")
+    notebook.add(tab_review_container, text="Review Management")
+    notebook.add(tab_validation_container, text="Validation & Results")
 
     # --- Status bar at bottom ---
     status_bar = ttk.Label(root, textvariable=status_var, relief=tk.SUNKEN, anchor="w")

--- a/ui/ui_helpers.py
+++ b/ui/ui_helpers.py
@@ -30,3 +30,28 @@ def create_horizontal_button_group(parent, buttons):
         button = ttk.Button(frame, text=label, command=command)
         button.pack(side="left", padx=5)
     return frame
+
+# Helper to create a scrollable frame within a tab
+import tkinter as tk
+
+def create_scrollable_frame(parent):
+    """Return a frame with vertical scrolling enabled."""
+    container = ttk.Frame(parent)
+    container.pack(fill="both", expand=True)
+
+    canvas = tk.Canvas(container, highlightthickness=0)
+    scrollbar = ttk.Scrollbar(container, orient="vertical", command=canvas.yview)
+    scrollable = ttk.Frame(canvas)
+
+    scrollable.bind(
+        "<Configure>",
+        lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+    )
+
+    canvas.create_window((0, 0), window=scrollable, anchor="nw")
+    canvas.configure(yscrollcommand=scrollbar.set)
+
+    canvas.pack(side="left", fill="both", expand=True)
+    scrollbar.pack(side="right", fill="y")
+
+    return scrollable


### PR DESCRIPTION
## Summary
- make all tabs scrollable by wrapping frames in a canvas and scrollbar
- expose new `create_scrollable_frame` helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f692dab28832ea92dd3c805c2d748