### PR TITLE
Constrain app layout width

### DIFF
--- a/tasks_users_ui.py
+++ b/tasks_users_ui.py
@@ -55,8 +55,10 @@ def add_task(task_name, project_id, cycle_id, start_date, end_date, assigned_to)
 # UI setup
 root = tk.Tk()
 root.title("Project Management")
+root.geometry("1280x800")
+root.resizable(False, True)
 notebook = ttk.Notebook(root)
-notebook.pack(expand=True, fill="both")
+notebook.pack(fill="both", expand=True)
 
 # Users Tab
 user_frame = ttk.Frame(notebook)
@@ -80,11 +82,17 @@ ttk.Button(user_frame, text="Add User", command=lambda: add_user(name_entry.get(
 project_frame = ttk.Frame(notebook)
 notebook.add(project_frame, text="Projects")
 
-ttk.Label(project_frame, text="Projects:").pack()
+ttk.Label(project_frame, text="Projects:").pack(anchor="w")
+project_frame.pack_propagate(False)
 project_tree = ttk.Treeview(project_frame, columns=("ID", "Name"), show="headings")
 project_tree.heading("ID", text="ID")
 project_tree.heading("Name", text="Project Name")
-project_tree.pack(expand=True, fill="both")
+project_tree.column("ID", width=60, stretch=False)
+project_tree.column("Name", width=250, stretch=False)
+project_tree.pack(side="left", fill="y")
+proj_scroll = ttk.Scrollbar(project_frame, orient="vertical", command=project_tree.yview)
+project_tree.configure(yscrollcommand=proj_scroll.set)
+proj_scroll.pack(side="right", fill="y")
 
 # Tasks Tab
 task_frame = ttk.Frame(notebook)
@@ -141,12 +149,20 @@ ttk.Button(task_frame, text="Add Task", command=lambda: add_task(
     assigned_to_var.get(),
 )).grid(row=6, columnspan=2)
 
+task_frame.grid_propagate(False)
 task_tree = ttk.Treeview(task_frame, columns=("name", "start", "end", "user"), show="headings")
 task_tree.heading("name", text="Task")
 task_tree.heading("start", text="Start")
 task_tree.heading("end", text="End")
 task_tree.heading("user", text="Assigned To")
-task_tree.grid(row=7, column=0, columnspan=2, pady=5)
+task_tree.column("name", width=250, stretch=False)
+task_tree.column("start", width=100, stretch=False)
+task_tree.column("end", width=100, stretch=False)
+task_tree.column("user", width=150, stretch=False)
+task_tree.grid(row=7, column=0, pady=5, sticky="ns")
+task_scroll = ttk.Scrollbar(task_frame, orient="vertical", command=task_tree.yview)
+task_tree.configure(yscrollcommand=task_scroll.set)
+task_scroll.grid(row=7, column=1, sticky="ns")
 
 def refresh_tasks():
     if " - " not in project_var.get():

--- a/ui/base_layout.py
+++ b/ui/base_layout.py
@@ -7,7 +7,9 @@ from .ui_helpers import create_scrollable_frame
 def build_main_ui():
     root = tk.Tk()
     root.title("Project & Review Management System")
-    root.geometry("1280x720")
+    # Constrain the application to a maximum width
+    root.geometry("1280x800")
+    root.resizable(False, True)
 
     # --- Status bar variable ---
     status_var = tk.StringVar()

--- a/ui/tab_data_imports.py
+++ b/ui/tab_data_imports.py
@@ -157,7 +157,10 @@ def build_data_imports_tab(tab, status_var):
     ])
 
     log_list = tk.Listbox(tab, width=80, height=5)
-    log_list.pack(padx=10, pady=5, anchor="w")
+    log_list.pack(padx=10, pady=5, anchor="w", fill="x")
+    log_scroll = ttk.Scrollbar(tab, orient="horizontal", command=log_list.xview)
+    log_list.configure(xscrollcommand=log_scroll.set)
+    log_scroll.pack(fill="x", padx=10)
 
     # --- ACC CSV Import Section ---
     ttk.Label(tab, text="ACC Export CSV Import", font=("Arial", 12, "bold")).pack(pady=20, anchor="w", padx=10)

--- a/ui/tab_project.py
+++ b/ui/tab_project.py
@@ -64,7 +64,7 @@ def build_project_tab(tab, status_var):
 
     for idx, (label, var) in enumerate(summary_vars.items()):
         ttk.Label(frame_summary, text=f"{label}:").grid(row=idx, column=0, sticky="w", padx=5, pady=2)
-        ttk.Label(frame_summary, textvariable=var).grid(row=idx, column=1, sticky="w", padx=5, pady=2)
+        ttk.Label(frame_summary, textvariable=var, wraplength=300).grid(row=idx, column=1, sticky="w", padx=5, pady=2)
 
     # ------------------------------------------------------------------
     # Column 1 - Selection & details
@@ -217,8 +217,12 @@ def build_project_tab(tab, status_var):
     # --- Recent File List ---
     frame_recent = ttk.LabelFrame(middle_col, text="Recent ACC Files")
     frame_recent.pack(fill="both", expand=True, pady=5)
+    frame_recent.pack_propagate(False)
     lst_recent = tk.Listbox(frame_recent, width=80, height=10)
     lst_recent.pack(padx=10, pady=5, anchor="w", fill="both", expand=True)
+    lst_scroll = ttk.Scrollbar(frame_recent, orient="horizontal", command=lst_recent.xview)
+    lst_recent.configure(xscrollcommand=lst_scroll.set)
+    lst_scroll.pack(side="bottom", fill="x")
 
     def update_results():
         lst_recent.delete(0, tk.END)

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -240,6 +240,7 @@ def build_review_tab(tab, status_var):
     # --- Reviewer Assignment Section ---
     frame_assignment = ttk.LabelFrame(column_container, text="Reviewer Assignment")
     frame_assignment.grid(row=2, column=0, columnspan=3, sticky="nsew", padx=10, pady=10)
+    frame_assignment.grid_propagate(False)
 
 
     summary_label = ttk.Label(frame_assignment, text="")
@@ -253,7 +254,11 @@ def build_review_tab(tab, status_var):
     tree_reviews.heading("date", text="Review Date")
     tree_reviews.heading("user", text="Reviewer")
     tree_reviews.heading("status", text="Status")
-    tree_reviews.pack(side="left", fill="both", expand=True)
+    tree_reviews.column("id", width=60, stretch=False)
+    tree_reviews.column("date", width=120, stretch=False)
+    tree_reviews.column("user", width=150, stretch=False)
+    tree_reviews.column("status", width=100, stretch=False)
+    tree_reviews.pack(side="left", fill="y")
     scroll = ttk.Scrollbar(frame_assignment, orient="vertical", command=tree_reviews.yview)
     tree_reviews.configure(yscrollcommand=scroll.set)
     scroll.pack(side="right", fill="y")

--- a/ui/ui_helpers.py
+++ b/ui/ui_helpers.py
@@ -74,8 +74,10 @@ import tkinter as tk
 
 def create_scrollable_frame(parent, scroll_x=False, scroll_y=True):
     """Create a scrollable frame that supports vertical and optionally horizontal scrolling."""
-    container = ttk.Frame(parent)
+    container = ttk.Frame(parent, width=1280)
     container.pack(fill="both", expand=True)
+    # Prevent children from expanding the container beyond its width
+    container.pack_propagate(False)
 
     canvas = tk.Canvas(container, highlightthickness=0)
     scrollable = ttk.Frame(canvas)


### PR DESCRIPTION
## Summary
- set default window to 1280px wide and lock horizontal resizing
- prevent scrollable frames from stretching beyond 1280px
- add column widths and scrollbars to tree/list widgets
- wrap long summary text in project tab

## Testing
- `python -m py_compile tasks_users_ui.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685b3a160bd4832e8254569473355eeb