### PR TITLE
Add contractual links support

### DIFF
--- a/database.py
+++ b/database.py
@@ -935,3 +935,68 @@ def get_review_summary(project_id, cycle_id):
         conn.close()
 
 
+def insert_contractual_link(project_id, review_cycle_id, bep_clause, billing_event, amount_due, status="Pending"):
+    """Insert a contractual link record."""
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO ContractualLinks (
+                project_id,
+                review_cycle_id,
+                bep_clause,
+                billing_event,
+                amount_due,
+                status
+            ) VALUES (?, ?, ?, ?, ?, ?);
+            """,
+            (project_id, review_cycle_id, bep_clause, billing_event, amount_due, status),
+        )
+        conn.commit()
+        return True
+    except Exception as e:
+        print(f"❌ Error inserting contractual link: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def get_contractual_links(project_id, review_cycle_id=None):
+    """Fetch contractual links for a project, optionally filtered by cycle."""
+    conn = connect_to_db()
+    if conn is None:
+        return []
+    try:
+        cursor = conn.cursor()
+        if review_cycle_id:
+            cursor.execute(
+                """
+                SELECT bep_clause, billing_event, amount_due, status
+                FROM ContractualLinks
+                WHERE project_id = ? AND review_cycle_id = ?
+                ORDER BY id;
+                """,
+                (project_id, review_cycle_id),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT bep_clause, billing_event, amount_due, status
+                FROM ContractualLinks
+                WHERE project_id = ?
+                ORDER BY id;
+                """,
+                (project_id,),
+            )
+        return [tuple(row) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"❌ Error fetching contractual links: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+

--- a/docs/review_management_plan.md
+++ b/docs/review_management_plan.md
@@ -1,0 +1,29 @@
+# Review Management Tab Design Review
+
+This document summarizes how the current `Review Management` tab relates to the desired all‑in‑one BIM Coordination Review Management tool. It provides a high level comparison of requested features with existing functionality and highlights areas for future work.
+
+## Requested Functionality
+- **Modular UI** with projects, review cycles and reviewer assignments.
+- Editable tables to manage review cycles and assignments.
+- Project summary panels and optional Gantt view.
+- Contract compliance tracking (BEP, fees, deliverables).
+
+The proposed data model includes tables for `Projects`, `ReviewCycles`, `ReviewAssignments` and `ContractualLinks`.
+
+## Current Implementation Overview
+The repository already provides a Tkinter based interface under `ui/tab_review.py` and associated database helpers:
+- Projects and review cycles are loaded from the database using helper functions in `database.py`.
+- Review schedules are created via `submit_review_schedule` in `review_handler.py` and displayed in a table where reviewers can be assigned.
+- A summary panel shows selected project metadata.
+- A Dash based `gantt_chart.py` visualises review dates.
+
+## Gaps and Potential Enhancements
+- **Inline Editing:** The current task table supports assigning reviewers but does not allow editing dates directly. Integrating inline editing for Treeview rows would align with the requested editable table feature.
+- **Contractual Data:** The database layer lacks the optional `ContractualLinks` table. Adding this table and exposing data through the UI would enable contract compliance tracking.
+- **Additional Metadata:** Fields such as fee, platforms and license duration are captured when submitting a schedule but are not yet surfaced in a dedicated project sidebar.
+
+## Next Steps
+1. Extend the database schema with `ReviewAssignments` and `ContractualLinks` as outlined in the proposal.
+2. Enhance `tab_review.py` to include inline editable cells for review dates and status, and to surface contractual information in the summary panel.
+3. Integrate the existing Gantt chart launch button more tightly with selected project and cycle information.
+

--- a/sql/add_contractual_links.sql
+++ b/sql/add_contractual_links.sql
@@ -1,0 +1,13 @@
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'ContractualLinks')
+BEGIN
+    CREATE TABLE ContractualLinks (
+        id INT IDENTITY(1,1) PRIMARY KEY,
+        project_id INT NOT NULL,
+        review_cycle_id INT NULL,
+        bep_clause NVARCHAR(255) NOT NULL,
+        billing_event NVARCHAR(255) NOT NULL,
+        amount_due DECIMAL(18,2) DEFAULT 0,
+        status NVARCHAR(50) DEFAULT 'Pending'
+    );
+END;
+GO

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -24,6 +24,7 @@ from database import (
     update_review_task_assignee,
     get_review_summary,
     get_project_review_progress,
+    get_contractual_links,
 )
 
 # Global reference to the project dropdown so other tabs can refresh it
@@ -113,6 +114,28 @@ def build_review_tab(tab, status_var):
         else:
             for v in summary_vars.values():
                 v.set("")
+
+    def show_contract_links():
+        if " - " not in cmb_projects.get():
+            messagebox.showerror("Error", "Select a project first")
+            return
+        pid = cmb_projects.get().split(" - ")[0]
+        cid = cmb_cycles.get() or None
+        links = get_contractual_links(pid, cid if cid else None)
+        win = tk.Toplevel(tab)
+        win.title("Contractual Links")
+        cols = ("BEP Clause", "Billing Event", "Amount Due", "Status")
+        tree = ttk.Treeview(win, columns=cols, show="headings")
+        for c in cols:
+            tree.heading(c, text=c)
+            tree.column(c, width=120, anchor="w")
+        for row in links:
+            tree.insert("", tk.END, values=row)
+        tree.pack(fill="both", expand=True)
+
+    ttk.Button(frame_summary, text="View Contract Links", command=show_contract_links).grid(
+        row=len(summary_vars), column=0, columnspan=2, pady=(10, 0)
+    )
 
     # --- Project & Cycle Selection ---
     projects = [f"{p[0]} - {p[1]}" for p in get_projects()]


### PR DESCRIPTION
## Summary
- extend database access layer with functions for ContractualLinks
- update Review tab UI with button to display contract links
- add SQL script to create ContractualLinks table

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_685c82149758832eb375dae804351cb4