### PR TITLE
Integrate combine_exports into importer

### DIFF
--- a/combine_exports.py
+++ b/combine_exports.py
@@ -1,5 +1,10 @@
-# combine_exports.py
-# Combines all JSON exports from Revit into a single merged JSON per project and timestamp
+"""Utility for merging multiple Revit health export JSON files.
+
+This module was originally a standalone script. The ``combine_exports`` function
+exposes the same behaviour for use by other modules (e.g. the health importer).
+When executed directly it behaves like the original script using the hard coded
+``EXPORT_DIR`` path.
+"""
 
 import os
 import json
@@ -8,40 +13,61 @@ import shutil
 from collections import defaultdict
 from datetime import datetime
 
+
 EXPORT_DIR = r"C:/Users/RicoStrinati/Documents/research/HealthCheck/dynamo/exports"
-PROCESSED_DIR = os.path.join(EXPORT_DIR, "processed")
-COMBINED_DIR = os.path.join(EXPORT_DIR, "combined")
-os.makedirs(PROCESSED_DIR, exist_ok=True)
-os.makedirs(COMBINED_DIR, exist_ok=True)
 
-# Regex pattern to extract type, filename and timestamp
-token_pattern = re.compile(r"^(.*?)_([^_]+)_((?:\d{8}_\d{6})).json$")
 
-# Collect files by project and timestamp
-groups = defaultdict(dict)
-for file in os.listdir(EXPORT_DIR):
-    if not file.endswith(".json"):
-        continue
-    match = token_pattern.match(file)
-    if not match:
-        continue
-    type_key, proj_name, timestamp = match.groups()
-    groups[(proj_name, timestamp)][type_key] = os.path.join(EXPORT_DIR, file)
+def combine_exports(export_dir: str) -> str:
+    """Combine JSON parts located in ``export_dir``.
 
-# Combine grouped files
-for (proj_name, timestamp), parts in groups.items():
-    merged = {"project": proj_name, "timestamp": timestamp}
-    for part_name, filepath in parts.items():
-        with open(filepath, "r") as f:
-            try:
-                merged[f"json_{part_name}"] = json.load(f)
-            except Exception as e:
-                print(f"❌ Failed to load {filepath}: {e}")
-                continue
-        shutil.move(filepath, os.path.join(PROCESSED_DIR, os.path.basename(filepath)))
+    Parameters
+    ----------
+    export_dir : str
+        Folder containing JSON parts exported from Revit.
 
-    output_filename = f"merged_{proj_name}_{timestamp}.json"
-    output_path = os.path.join(COMBINED_DIR, output_filename)
-    with open(output_path, "w") as out_file:
-        json.dump(merged, out_file, indent=2)
-    print(f"✅ Combined JSON created: {output_path}")
+    Returns
+    -------
+    str
+        Path to the directory containing the combined JSON files.
+    """
+
+    processed_dir = os.path.join(export_dir, "processed")
+    combined_dir = os.path.join(export_dir, "combined")
+    os.makedirs(processed_dir, exist_ok=True)
+    os.makedirs(combined_dir, exist_ok=True)
+
+    # Regex pattern to extract type, project filename and timestamp
+    token_pattern = re.compile(r"^(.*?)_([^_]+)_((?:\d{8}_\d{6})).json$")
+
+    groups = defaultdict(dict)
+    for file in os.listdir(export_dir):
+        if not file.endswith(".json"):
+            continue
+        match = token_pattern.match(file)
+        if not match:
+            continue
+        type_key, proj_name, timestamp = match.groups()
+        groups[(proj_name, timestamp)][type_key] = os.path.join(export_dir, file)
+
+    for (proj_name, timestamp), parts in groups.items():
+        merged = {"project": proj_name, "timestamp": timestamp}
+        for part_name, filepath in parts.items():
+            with open(filepath, "r") as f:
+                try:
+                    merged[f"json_{part_name}"] = json.load(f)
+                except Exception as e:
+                    print(f"❌ Failed to load {filepath}: {e}")
+                    continue
+            shutil.move(filepath, os.path.join(processed_dir, os.path.basename(filepath)))
+
+        output_filename = f"merged_{proj_name}_{timestamp}.json"
+        output_path = os.path.join(combined_dir, output_filename)
+        with open(output_path, "w") as out_file:
+            json.dump(merged, out_file, indent=2)
+        print(f"✅ Combined JSON created: {output_path}")
+
+    return combined_dir
+
+
+if __name__ == "__main__":
+    combine_exports(EXPORT_DIR)


### PR DESCRIPTION
## Summary
- expose `combine_exports` as a reusable function
- clear and write a log during `rvt_health_importer` execution
- automatically combine exports before importing into the database

## Testing
- `python -m py_compile rvt_health_importer.py combine_exports.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbd791788832ea9e7f8950cc15a92