### PR TITLE
Skip uncombined health JSON files

### DIFF
--- a/rvt_health_importer.py
+++ b/rvt_health_importer.py
@@ -53,6 +53,9 @@ def import_health_data(json_folder, db_name=None):
     for file in os.listdir(json_folder):
         if not file.endswith(".json"):
             continue
+        if "_combined.json" not in file.lower():
+            log(f"[SKIPPED] Skipping uncombined file: {file}")
+            continue
         full_path = os.path.join(json_folder, file)
         log(f"[FILE] Processing {file}")
         try:


### PR DESCRIPTION
## Summary
- filter out uncombined files in `rvt_health_importer.py` so only `<project>_combined.json` files get loaded

## Testing
- `python -m py_compile rvt_health_importer.py`


------
https://chatgpt.com/codex/tasks/task_e_68625b8f2a2c832e94fbd4f281b30171