### PR TITLE
Handle model file size from metadata

### DIFF
--- a/combine_exports.py
+++ b/combine_exports.py
@@ -90,6 +90,10 @@ def combine_files_into_dict(export_dir, file_list) -> Dict[str, Any]:
             for key in content:
                 data[key] = content[key]
 
+            # Map old metadata key to the ordered key expected downstream
+            if "ModelFileSizeMB" in content:
+                data["nModelFileSizeMB"] = content["ModelFileSizeMB"]
+
             # ✅ Check and include base/survey point if available
             if "projectBasePoint" in content:
                 data["jsonProjectBasePoint"] = json.dumps(content["projectBasePoint"])

--- a/rvt_health_importer.py
+++ b/rvt_health_importer.py
@@ -112,7 +112,7 @@ def import_health_data(json_folder, db_name=None):
                 data.get("jsonGrids"),
                 json.dumps(data.get("projectBasePoint")),
                 json.dumps(data.get("surveyPoint")),
-                safe_float(data.get("ModelFileSizeMB")),
+                safe_float(data.get("ModelFileSizeMB") or data.get("nModelFileSizeMB")),
                 data.get("jsonTitleBlocksSummary")
             ))
 


### PR DESCRIPTION
## Summary
- preserve `ModelFileSizeMB` value when combining exports
- allow health importer to read either `ModelFileSizeMB` or `nModelFileSizeMB`

## Testing
- `python -m py_compile combine_exports.py rvt_health_importer.py`

------
https://chatgpt.com/codex/tasks/task_e_6863115d8b9c832e8abaa5534426bd75