### PR TITLE
Add microsecond support to datetime parser

### DIFF
--- a/acc_handler.py
+++ b/acc_handler.py
@@ -78,7 +78,7 @@ def parse_custom_datetime(val, col_name):
     val = val.strip()
 
     # Accept known good formats
-    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%d/%m/%Y %H:%M", "%Y-%m-%dT%H:%M:%S"):
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%d/%m/%Y %H:%M", "%Y-%m-%dT%H:%M:%S"):
         try:
             return datetime.datetime.strptime(val, fmt)
         except ValueError:

--- a/tests/test_acc_handler.py
+++ b/tests/test_acc_handler.py
@@ -1,0 +1,24 @@
+import datetime
+import os
+import sys
+import types
+
+dummy = types.ModuleType("dummy")
+for mod in ["pandas", "pyodbc", "sqlparse"]:
+    sys.modules.setdefault(mod, dummy)
+
+tk_mod = types.ModuleType("tkinter")
+tk_mod.ttk = types.ModuleType("ttk")
+tk_mod.messagebox = types.ModuleType("messagebox")
+sys.modules.setdefault("tkinter", tk_mod)
+sys.modules.setdefault("tkinter.ttk", tk_mod.ttk)
+sys.modules.setdefault("tkinter.messagebox", tk_mod.messagebox)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from acc_handler import parse_custom_datetime
+
+
+def test_parse_custom_datetime_microseconds():
+    dt_str = "2025-07-01 04:24:43.189"
+    parsed = parse_custom_datetime(dt_str, "created_at")
+    assert parsed == datetime.datetime(2025, 7, 1, 4, 24, 43, 189000)


### PR DESCRIPTION
## Summary
- allow `parse_custom_datetime` to parse `%Y-%m-%d %H:%M:%S.%f`
- add unit test for microsecond handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc7debc88832eb9effe6939e3ebb6