### PR TITLE
Add environment setup script and dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ Set the following variables before running the tools:
 - `REVIT_HEALTH_DB` – Revit health check database name (default `RevitHealthCheckDB`)
 
 These variables can be placed in your shell profile or a `.env` file loaded before execution.
+
+## Setup
+
+Install a compatible ODBC driver for SQL Server (see [docs/setup.md](docs/setup.md)) and ensure the environment variables above are set. Then run:
+
+```bash
+./setup_env.sh
+```
+
+This creates a virtual environment in `.venv` and installs the Python dependencies listed in `requirements.txt`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,33 @@
+# Environment Setup
+
+This project connects to a SQL Server database via ODBC. Install the Microsoft ODBC driver before installing Python dependencies.
+
+## Install ODBC Driver
+
+- **Windows:** Download and install the latest *ODBC Driver for SQL Server* from the [Microsoft website](https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server).
+- **macOS:** `brew install msodbcsql18`
+- **Linux (Debian/Ubuntu):** `sudo apt-get install msodbcsql18`
+
+## Python Environment
+
+Run the provided script to create a virtual environment and install the required packages:
+
+```bash
+./setup_env.sh
+```
+
+The script creates a `.venv` folder and runs `pip install -r requirements.txt` inside it.
+
+## Required Environment Variables
+
+Set the following variables before running the tools:
+
+- `DB_SERVER` – SQL Server host (default `...`)
+- `DB_USER` – database username (default `...`)
+- `DB_PASSWORD` – database password (default `...`)
+- `DB_DRIVER` – ODBC driver name (default `...`)
+- `PROJECT_MGMT_DB` – default project management database (default `ProjectManagement`)
+- `ACC_DB` – Autodesk Construction Cloud staging database (default `acc_data_schema`)
+- `REVIT_HEALTH_DB` – Revit health check database (default `RevitHealthCheckDB`)
+
+These variables can be stored in your shell profile or in a `.env` file loaded before execution.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+pyodbc
+dash
+plotly
+python-dateutil
+ifcopenshell
+sqlparse
+tkcalendar

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- list runtime dependencies in requirements.txt
- add `setup_env.sh` script to create a virtual environment
- document setup instructions in a new `docs/setup.md`
- mention the new setup process in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n setup_env.sh`
- `./setup_env.sh` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686dca6df6c4832ebbbaf3de5665cf9a