### PR TITLE
Add date editing improvements and override tracking

### DIFF
--- a/review_handler.py
+++ b/review_handler.py
@@ -18,11 +18,14 @@ def update_review_date(review_id, new_date):
     """Update a specific review date."""
     conn = connect_to_db()
     cursor = conn.cursor()
-    cursor.execute("""
+    cursor.execute(
+        """
         UPDATE ReviewSchedule
-        SET review_date = ?
+        SET review_date = ?, manual_override = 1
         WHERE review_id = ?;
-    """, (new_date, review_id))
+    """,
+        (new_date, review_id),
+    )
     conn.commit()
     conn.close()
 

--- a/tests/test_review_handler.py
+++ b/tests/test_review_handler.py
@@ -27,7 +27,7 @@ sys.modules.setdefault("tkinter.messagebox", _tk.messagebox)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from review_handler import generate_stage_review_schedule
+from review_handler import generate_stage_review_schedule, update_review_date
 
 
 class FakeCursor:
@@ -102,3 +102,15 @@ def test_generate_stage_review_schedule_no_connection():
     with patch("review_handler.connect_to_db", return_value=None):
         result = generate_stage_review_schedule(1, [])
     assert result is False
+
+
+def test_update_review_date_sets_manual_override():
+    cursor = FakeCursor()
+    conn = FakeConnection(cursor)
+
+    with patch("review_handler.connect_to_db", return_value=conn):
+        update_review_date(5, "2024-05-01")
+
+    assert conn.committed
+    assert ("manual_override = 1" in cursor.executed[0][0])
+    assert cursor.executed[0][1] == ("2024-05-01", 5)

--- a/ui/tab_review.py
+++ b/ui/tab_review.py
@@ -393,6 +393,15 @@ def build_review_tab(tab, status_var):
     tree_cycles.configure(yscrollcommand=cycle_scroll.set)
     cycle_scroll.pack(side="right", fill="y")
 
+    date_columns = {
+        "Planned Start",
+        "Planned Completion",
+        "Actual Start",
+        "Actual Completion",
+        "Hold",
+        "Resume",
+    }
+
     cycle_data = []
 
     def add_cycle_row():
@@ -411,8 +420,22 @@ def build_review_tab(tab, status_var):
             return
         x, y, width, height = tree_cycles.bbox(row_id, col)
         column_index = int(col[1:]) - 1
-        edit_var.set(tree_cycles.set(row_id, column=cycle_columns[column_index]))
-        entry = ttk.Entry(tree_cycles, textvariable=edit_var)
+        column_name = cycle_columns[column_index]
+        edit_var.set(tree_cycles.set(row_id, column=column_name))
+
+        if column_name in date_columns:
+            entry = DateEntry(
+                tree_cycles,
+                textvariable=edit_var,
+                date_pattern="yyyy-mm-dd",
+            )
+            try:
+                entry.set_date(datetime.datetime.strptime(edit_var.get(), "%Y-%m-%d").date())
+            except Exception:
+                pass
+        else:
+            entry = ttk.Entry(tree_cycles, textvariable=edit_var)
+
         entry.place(x=x, y=y, width=width, height=height)
         entry.focus()
 


### PR DESCRIPTION
## Summary
- make tree cycle editor use DateEntry for date columns
- mark edited review dates with `manual_override`
- test manual override behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877340f9f08832e82cde4b70e4355c6