### PR TITLE
Add Flask dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Install a compatible ODBC driver for SQL Server (see [docs/setup.md](docs/setup.
 ./setup_env.sh
 ```
 
-This creates a virtual environment in `.venv` and installs the Python dependencies listed in `requirements.txt`.
+This creates a virtual environment in `.venv` and installs the Python dependencies listed in `requirements.txt`, including the Flask components used by the backend.
+
+The requirements now include `Flask` and `Flask-Cors` for the API server.
 
 ## Local Web Application
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ python-dateutil
 ifcopenshell
 sqlparse
 tkcalendar
+Flask
+Flask-Cors


### PR DESCRIPTION
## Summary
- include Flask and Flask-Cors in requirements
- mention Flask dependencies in README and clarify what `setup_env.sh` installs

## Testing
- `pytest -q`
- `python -m backend.app` *(fails: No module named 'flask')*
- `./setup_env.sh` *(fails: could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_688996629b30832ea7d0e821b6b503b3