### PR TITLE
Extend frontend and backend with additional API endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,10 @@ from database import (
     get_review_tasks,
     update_review_task_assignee,
     get_users_list,
+    get_project_details,
+    get_review_summary,
+    get_contractual_links,
+    get_cycle_ids,
 )
 
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
@@ -57,6 +61,51 @@ def api_update_review_task(schedule_id):
     if success:
         return jsonify({'success': True})
     return jsonify({'success': False}), 500
+
+
+@app.route('/api/project/<int:project_id>', methods=['GET'])
+def api_get_project_details_endpoint(project_id):
+    details = get_project_details(project_id)
+    if details is None:
+        return jsonify({'error': 'project not found'}), 404
+    return jsonify(details)
+
+
+@app.route('/api/review_summary', methods=['GET'])
+def api_review_summary():
+    project_id = request.args.get('project_id')
+    cycle_id = request.args.get('cycle_id')
+    if not project_id or not cycle_id:
+        return jsonify({'error': 'project_id and cycle_id required'}), 400
+    summary = get_review_summary(project_id, cycle_id)
+    if summary is None:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(summary)
+
+
+@app.route('/api/contractual_links', methods=['GET'])
+def api_contractual_links():
+    project_id = request.args.get('project_id')
+    cycle_id = request.args.get('cycle_id')
+    if not project_id:
+        return jsonify({'error': 'project_id required'}), 400
+    links = get_contractual_links(project_id, cycle_id)
+    data = [
+        {
+            'bep_clause': b,
+            'billing_event': ev,
+            'amount_due': amt,
+            'status': status,
+        }
+        for b, ev, amt, status in links
+    ]
+    return jsonify(data)
+
+
+@app.route('/api/cycle_ids/<int:project_id>', methods=['GET'])
+def api_cycle_ids(project_id):
+    cycles = get_cycle_ids(project_id)
+    return jsonify(cycles)
 
 
 @app.route('/')

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,8 +3,12 @@ const { useEffect, useState } = React;
 function ReviewTasks() {
   const [projects, setProjects] = useState([]);
   const [projectId, setProjectId] = useState('');
+  const [cycleId, setCycleId] = useState('');
+  const [cycles, setCycles] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [users, setUsers] = useState([]);
+  const [projectDetails, setProjectDetails] = useState(null);
+  const [reviewSummary, setReviewSummary] = useState(null);
 
   useEffect(() => {
     fetch('/api/projects')
@@ -17,11 +21,30 @@ function ReviewTasks() {
 
   useEffect(() => {
     if (projectId) {
-      fetch(`/api/review_tasks?project_id=${projectId}&cycle_id=1`)
+      fetch(`/api/cycle_ids/${projectId}`)
+        .then(res => res.json())
+        .then(c => {
+          setCycles(c);
+          setCycleId(c[0] || '');
+        });
+      fetch(`/api/project/${projectId}`)
+        .then(res => res.json())
+        .then(setProjectDetails);
+      const cid = cycleId || (cycles[0] || 1);
+      fetch(`/api/review_summary?project_id=${projectId}&cycle_id=${cid}`)
+        .then(res => res.json())
+        .then(setReviewSummary);
+      fetch(`/api/review_tasks?project_id=${projectId}&cycle_id=${cid}`)
         .then(res => res.json())
         .then(setTasks);
+    } else {
+      setProjectDetails(null);
+      setReviewSummary(null);
+      setTasks([]);
+      setCycles([]);
+      setCycleId('');
     }
-  }, [projectId]);
+  }, [projectId, cycleId]);
 
   const assignUser = (scheduleId, userId) => {
     fetch(`/api/review_task/${scheduleId}`, {
@@ -30,7 +53,8 @@ function ReviewTasks() {
       body: JSON.stringify({ user_id: userId })
     }).then(() => {
       // refresh after update
-      fetch(`/api/review_tasks?project_id=${projectId}&cycle_id=1`)
+      const cid = cycleId || (cycles[0] || 1);
+      fetch(`/api/review_tasks?project_id=${projectId}&cycle_id=${cid}`)
         .then(res => res.json())
         .then(setTasks);
     });
@@ -45,6 +69,32 @@ function ReviewTasks() {
           <option key={p.project_id} value={p.project_id}>{p.project_name}</option>
         ))}
       </select>
+      {cycles.length > 0 && (
+        <select value={cycleId} onChange={e => setCycleId(e.target.value)} style={{marginLeft:'10px'}}>
+          {cycles.map(c => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      )}
+      {projectDetails && (
+        <div style={{marginTop: '10px'}}>
+          <h3>Project Details</h3>
+          <p>Status: {projectDetails.status}</p>
+          <p>Priority: {projectDetails.priority}</p>
+          <p>Start: {projectDetails.start_date}</p>
+          <p>End: {projectDetails.end_date}</p>
+        </div>
+      )}
+
+      {reviewSummary && (
+        <div style={{marginTop: '10px'}}>
+          <h3>Review Summary</h3>
+          <p>Cycle: {reviewSummary.cycle_id}</p>
+          <p>Scoped: {reviewSummary.scoped_reviews}</p>
+          <p>Completed: {reviewSummary.completed_reviews}</p>
+        </div>
+      )}
+
       <table border="1" cellPadding="4" style={{marginTop: '10px'}}>
         <thead>
           <tr>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,3 +31,36 @@ def test_patch_review_task(monkeypatch):
     assert resp.status_code == 200
     assert resp.get_json()['success'] is True
     assert called == {'schedule_id': 5, 'user_id': 8}
+
+
+def test_get_project_details(monkeypatch):
+    monkeypatch.setattr('backend.app.get_project_details', lambda pid: {'project_name': 'P', 'start_date': '2024-01-01', 'end_date': '2024-12-31', 'status': 'Active', 'priority': 'High'})
+    client = app.test_client()
+    resp = client.get('/api/project/1')
+    assert resp.status_code == 200
+    assert resp.get_json()['project_name'] == 'P'
+
+
+def test_review_summary(monkeypatch):
+    monkeypatch.setattr('backend.app.get_review_summary', lambda p, c: {'cycle_id': c, 'scoped_reviews': 5})
+    client = app.test_client()
+    resp = client.get('/api/review_summary?project_id=1&cycle_id=2')
+    assert resp.status_code == 200
+    assert resp.get_json()['cycle_id'] == '2'
+
+
+def test_contractual_links(monkeypatch):
+    monkeypatch.setattr('backend.app.get_contractual_links', lambda p, c=None: [('clause', 'event', 100, 'Pending')])
+    client = app.test_client()
+    resp = client.get('/api/contractual_links?project_id=1&cycle_id=2')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]['bep_clause'] == 'clause'
+
+
+def test_cycle_ids(monkeypatch):
+    monkeypatch.setattr('backend.app.get_cycle_ids', lambda pid: ['1', '2'])
+    client = app.test_client()
+    resp = client.get('/api/cycle_ids/1')
+    assert resp.status_code == 200
+    assert resp.get_json() == ['1', '2']


### PR DESCRIPTION
## Summary
- implement new backend API endpoints for project details, review summary, contractual links and cycle IDs
- integrate these endpoints into the React frontend
- update review tasks table to use selected cycle
- add tests for new API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b490f9a4832ebb6f30d29abec227