### PR TITLE
Add React Supabase wireframe

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <title>BIM Project Management</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="wireframe.css" />
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@supabase/supabase-js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 </head>
 <body>
   <div id="root"></div>
-  <script type="text/babel" src="app.js"></script>
+  <script type="text/babel" src="wireframe.js"></script>
 </body>
 </html>

--- a/frontend/wireframe.css
+++ b/frontend/wireframe.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+}
+
+.app-container {
+  display: flex;
+  height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background-color: #1e1e2f;
+  color: #fff;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar h2 {
+  font-size: 1.2rem;
+  margin: 0;
+  padding: 1rem;
+  border-bottom: 1px solid #333;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex-grow: 1;
+}
+
+.sidebar li {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+}
+
+.sidebar li:hover {
+  background-color: #31314f;
+}
+
+.sidebar li.active {
+  background-color: #3f3f5f;
+}
+
+.main {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  height: 50px;
+  background-color: #ffffff;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+}
+
+.content {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}

--- a/frontend/wireframe.js
+++ b/frontend/wireframe.js
@@ -1,0 +1,84 @@
+const { useState } = React;
+const { createClient } = supabase;
+
+// TODO: replace with your Supabase project credentials
+const supabaseUrl = 'https://your-project.supabase.co';
+const supabaseKey = 'public-anon-key';
+const supabaseClient = createClient(supabaseUrl, supabaseKey);
+
+function Sidebar({ active, onChange }) {
+  const items = [
+    { key: 'projects', label: 'Projects' },
+    { key: 'bep', label: 'BEP Manager' },
+    { key: 'imports', label: 'Data Imports' },
+    { key: 'reviews', label: 'Review Cycles' },
+    { key: 'validation', label: 'Validation' },
+    { key: 'issues', label: 'Coordination Issues' },
+    { key: 'kpis', label: 'KPIs & Reports' },
+  ];
+  return (
+    <div className="sidebar">
+      <h2>BIM PM</h2>
+      <ul>
+        {items.map(it => (
+          <li key={it.key}
+              className={active === it.key ? 'active' : ''}
+              onClick={() => onChange(it.key)}>
+            {it.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TopBar() {
+  return (
+    <div className="topbar">
+      <div>
+        <select>
+          <option>Project A</option>
+          <option>Project B</option>
+        </select>
+      </div>
+      <div>User</div>
+    </div>
+  );
+}
+
+function Placeholder({ title }) {
+  return (
+    <div>
+      <h3>{title}</h3>
+      <p>Content coming soon...</p>
+    </div>
+  );
+}
+
+const pages = {
+  projects: () => <Placeholder title="Projects" />,
+  bep: () => <Placeholder title="BEP Manager" />,
+  imports: () => <Placeholder title="Data Imports" />,
+  reviews: () => <Placeholder title="Review Cycles" />,
+  validation: () => <Placeholder title="Validation" />,
+  issues: () => <Placeholder title="Coordination Issues" />,
+  kpis: () => <Placeholder title="KPIs & Reports" />,
+};
+
+function App() {
+  const [page, setPage] = useState('projects');
+  const Page = pages[page];
+  return (
+    <div className="app-container">
+      <Sidebar active={page} onChange={setPage} />
+      <div className="main">
+        <TopBar />
+        <div className="content">
+          <Page />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- modernize the frontend index to load a new wireframe layout
- implement placeholder layout using React and Supabase
- add styling for sidebar, header, and content panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd59000ec832e8623f8a5363d9f09