### PR TITLE
Implement review cycle and BEP APIs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,15 @@ from database import (
     get_review_summary,
     get_contractual_links,
     get_cycle_ids,
+    get_review_cycles,
+    create_review_cycle,
+    update_review_cycle,
+    delete_review_cycle,
+    get_review_cycle_tasks,
+    update_review_cycle_task,
+    get_bep_matrix,
+    upsert_bep_section,
+    update_bep_status,
 )
 
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
@@ -167,6 +176,126 @@ def api_contractual_links():
 def api_cycle_ids(project_id):
     cycles = get_cycle_ids(project_id)
     return jsonify(cycles)
+
+
+@app.route('/api/reviews/<int:project_id>', methods=['GET'])
+def api_get_review_cycles_endpoint(project_id):
+    cycles = get_review_cycles(project_id)
+    data = [
+        {
+            'review_cycle_id': cid,
+            'stage_id': stage,
+            'start_date': s,
+            'end_date': e,
+            'num_reviews': n,
+        }
+        for cid, stage, s, e, n in cycles
+    ]
+    return jsonify(data)
+
+
+@app.route('/api/reviews', methods=['POST'])
+def api_create_review_cycle_endpoint():
+    body = request.get_json() or {}
+    required = ['project_id', 'stage_id', 'start_date', 'end_date', 'num_reviews', 'created_by']
+    if not all(k in body for k in required):
+        return jsonify({'error': 'missing fields'}), 400
+    new_id = create_review_cycle(
+        body['project_id'],
+        body['stage_id'],
+        body['start_date'],
+        body['end_date'],
+        body['num_reviews'],
+        body['created_by'],
+    )
+    if new_id is None:
+        return jsonify({'success': False}), 500
+    return jsonify({'id': new_id}), 201
+
+
+@app.route('/api/reviews/<int:cycle_id>', methods=['PUT'])
+def api_update_review_cycle_endpoint(cycle_id):
+    body = request.get_json() or {}
+    success = update_review_cycle(
+        cycle_id,
+        body.get('start_date'),
+        body.get('end_date'),
+        body.get('num_reviews'),
+        body.get('stage_id'),
+    )
+    return jsonify({'success': bool(success)})
+
+
+@app.route('/api/reviews/<int:cycle_id>', methods=['DELETE'])
+def api_delete_review_cycle_endpoint(cycle_id):
+    success = delete_review_cycle(cycle_id)
+    if success:
+        return jsonify({'success': True})
+    return jsonify({'success': False}), 500
+
+
+@app.route('/api/review_tasks/<int:schedule_id>', methods=['GET'])
+def api_get_review_cycle_tasks_endpoint(schedule_id):
+    tasks = get_review_cycle_tasks(schedule_id)
+    data = [
+        {
+            'review_task_id': tid,
+            'task_id': t,
+            'assigned_to': a,
+            'status': st,
+        }
+        for tid, t, a, st in tasks
+    ]
+    return jsonify(data)
+
+
+@app.route('/api/review_tasks/<int:task_id>', methods=['PUT'])
+def api_update_review_cycle_task_endpoint(task_id):
+    body = request.get_json() or {}
+    success = update_review_cycle_task(task_id, body.get('assigned_to'), body.get('status'))
+    return jsonify({'success': bool(success)})
+
+
+@app.route('/api/bep/<int:project_id>', methods=['GET'])
+def api_get_bep_matrix(project_id):
+    rows = get_bep_matrix(project_id)
+    data = [
+        {
+            'section_id': sid,
+            'title': title,
+            'responsible_user_id': uid,
+            'status': status,
+            'notes': notes,
+        }
+        for sid, title, uid, status, notes in rows
+    ]
+    return jsonify(data)
+
+
+@app.route('/api/bep/section', methods=['POST'])
+def api_upsert_bep_section():
+    body = request.get_json() or {}
+    required = ['project_id', 'section_id']
+    if not all(k in body for k in required):
+        return jsonify({'error': 'missing fields'}), 400
+    success = upsert_bep_section(
+        body['project_id'],
+        body['section_id'],
+        body.get('responsible_user_id'),
+        body.get('status'),
+        body.get('notes'),
+    )
+    return jsonify({'success': bool(success)})
+
+
+@app.route('/api/bep/status', methods=['PUT'])
+def api_update_bep_status_endpoint():
+    body = request.get_json() or {}
+    required = ['project_id', 'section_id', 'status']
+    if not all(k in body for k in required):
+        return jsonify({'error': 'missing fields'}), 400
+    success = update_bep_status(body['project_id'], body['section_id'], body['status'])
+    return jsonify({'success': bool(success)})
 
 
 @app.route('/')

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -124,6 +124,62 @@ function ReviewTasks() {
   );
 }
 
+function ReviewCycles() {
+  const [projects, setProjects] = useState([]);
+  const [projectId, setProjectId] = useState('');
+  const [cycles, setCycles] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/projects')
+      .then(res => res.json())
+      .then(setProjects);
+  }, []);
+
+  useEffect(() => {
+    if (projectId) {
+      fetch(`/api/reviews/${projectId}`)
+        .then(res => res.json())
+        .then(setCycles);
+    } else {
+      setCycles([]);
+    }
+  }, [projectId]);
+
+  return (
+    <div>
+      <h2>Review Cycles</h2>
+      <select value={projectId} onChange={e => setProjectId(e.target.value)}>
+        <option value="">Select Project</option>
+        {projects.map(p => (
+          <option key={p.project_id} value={p.project_id}>{p.project_name}</option>
+        ))}
+      </select>
+      <table border="1" cellPadding="4" style={{marginTop:'10px'}}>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Stage</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Reviews</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cycles.map(c => (
+            <tr key={c.review_cycle_id}>
+              <td>{c.review_cycle_id}</td>
+              <td>{c.stage_id}</td>
+              <td>{c.start_date}</td>
+              <td>{c.end_date}</td>
+              <td>{c.num_reviews}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function ProjectManagement() {
   const [projects, setProjects] = useState([]);
   const [projectId, setProjectId] = useState('');
@@ -250,9 +306,10 @@ function App() {
     <div>
       <div>
         <button onClick={() => setView('review')}>Review Tasks</button>
+        <button onClick={() => setView('cycles')}>Review Cycles</button>
         <button onClick={() => setView('project')}>Project Setup</button>
       </div>
-      {view === 'review' ? <ReviewTasks /> : <ProjectManagement />}
+      {view === 'review' ? <ReviewTasks /> : view === 'cycles' ? <ReviewCycles /> : <ProjectManagement />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add new database helpers for review cycle, task and BEP management
- expose REST API endpoints for cycles, tasks and BEP matrix
- extend React UI with ReviewCycles component
- expand API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c006086f8832eb539fb07070cf85f