### PR TITLE
Add project creation modal and fix DB utils

### DIFF
--- a/database.py
+++ b/database.py
@@ -1141,7 +1141,11 @@ def get_bep_matrix(project_id):
         return [tuple(row) for row in cursor.fetchall()]
     except Exception as e:
         print(f"❌ Error fetching BEP matrix: {e}")
-=======
+        return []
+    finally:
+        conn.close()
+
+
 def get_projects_full():
     """Return all rows from the vw_projects_full view."""
     conn = connect_to_db()
@@ -1164,15 +1168,11 @@ def get_projects_full():
 def upsert_bep_section(project_id, section_id, responsible_user_id, status, notes):
     """Create or update a project BEP section record."""
 
-def update_project_financials(project_id, contract_value=None, payment_terms=None):
-    """Update financial fields in the projects table."""
-
     conn = connect_to_db()
     if conn is None:
         return False
     try:
         cursor = conn.cursor()
-
         cursor.execute(
             """
             MERGE project_bep_sections AS tgt
@@ -1199,7 +1199,19 @@ def update_project_financials(project_id, contract_value=None, payment_terms=Non
         return True
     except Exception as e:
         print(f"❌ Error upserting BEP section: {e}")
-=======
+        return False
+    finally:
+        conn.close()
+
+
+def update_project_financials(project_id, contract_value=None, payment_terms=None):
+    """Update financial fields in the projects table."""
+
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
         sets = []
         params = []
         if contract_value is not None:
@@ -1225,15 +1237,11 @@ def update_project_financials(project_id, contract_value=None, payment_terms=Non
 def update_bep_status(project_id, section_id, status):
     """Update the status of a BEP section for a project."""
 
-def update_client_info(project_id, client_contact=None, contact_email=None):
-    """Update client contact details for a project."""
-
     conn = connect_to_db()
     if conn is None:
         return False
     try:
         cursor = conn.cursor()
-
         cursor.execute(
             "UPDATE project_bep_sections SET status = ? WHERE project_id = ? AND section_id = ?;",
             (status, project_id, section_id),
@@ -1242,6 +1250,19 @@ def update_client_info(project_id, client_contact=None, contact_email=None):
         return True
     except Exception as e:
         print(f"❌ Error updating BEP status: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def update_client_info(project_id, client_contact=None, contact_email=None):
+    """Update client contact details for a project."""
+
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
 
         sets = []
         params = []
@@ -1259,7 +1280,6 @@ def update_client_info(project_id, client_contact=None, contact_email=None):
         return True
     except Exception as e:
         print(f"❌ Error updating client info: {e}")
-
         return False
     finally:
         conn.close()

--- a/frontend/wireframe.js
+++ b/frontend/wireframe.js
@@ -135,6 +135,34 @@ function EditProject({ project, onClose }) {
   );
 }
 
+function AddProject({ onClose }) {
+  const [form, setForm] = useState({ project_name: '' });
+
+  const save = () => {
+    fetch('/api/project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    }).then(onClose);
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h4>New Project</h4>
+        <TextField label="Project Name" fullWidth margin="dense"
+          value={form.project_name}
+          onChange={e => setForm({ project_name: e.target.value })}
+        />
+        <div style={{ marginTop: '1rem' }}>
+          <Button variant="contained" onClick={save}>Create</Button>
+          <Button onClick={onClose} style={{ marginLeft: '1rem' }}>Cancel</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function TabPanel({ children, value, index }) {
   return (
     <div role="tabpanel" hidden={value !== index}>
@@ -205,6 +233,7 @@ function ProjectsPage() {
   const [status, setStatus] = useState('');
   const [selected, setSelected] = useState(null);
   const [editing, setEditing] = useState(null);
+  const [adding, setAdding] = useState(false);
   const [projects, setProjects] = useState([]);
 
   useEffect(() => {
@@ -240,6 +269,17 @@ function ProjectsPage() {
     return <EditProject project={editing} onClose={refresh} />;
   }
 
+  if (adding) {
+    const refresh = () => {
+      setAdding(false);
+      fetch('/api/projects_full')
+        .then(res => res.ok ? res.json() : Promise.reject())
+        .then(setProjects)
+        .catch(() => {});
+    };
+    return <AddProject onClose={refresh} />;
+  }
+
   return (
     <div>
       <h3>Projects</h3>
@@ -253,6 +293,9 @@ function ProjectsPage() {
             <MenuItem value="Planning">Planning</MenuItem>
           </Select>
         </FormControl>
+        <Button variant="contained" size="small" onClick={() => setAdding(true)}>
+          New Project
+        </Button>
       </div>
       <TableContainer component={Paper}>
         <Table size="small">


### PR DESCRIPTION
## Summary
- repair syntax errors in `database.py`
- add `AddProject` modal to React wireframe UI
- allow project creation from the Projects page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c0510c414832e90ebcaf68dedcc9d