### PR TITLE
Expose flask_app from backend package

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import threading
 import subprocess
 import webbrowser
 
-from backend.app import app
+from backend import flask_app
 from config import Config
 
 server = Config.DB_SERVER
@@ -25,6 +25,6 @@ if __name__ == "__main__":
     _launch_tkinter()
     # Start a timer to open the browser after the server starts
     threading.Timer(1.0, _open_browser).start()
-    app.run(debug=True, use_reloader=False)
+    flask_app.run(debug=True, use_reloader=False)
 
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,4 @@
-from .app import app
+"""Expose the Flask application with a clearer name."""
+
+from .app import app as flask_app
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import types
 import pytest
 
 flask = pytest.importorskip("flask")
-from backend.app import app
+from backend import flask_app as app
 
 # Mock heavy dependencies
 _dummy = types.ModuleType("dummy")


### PR DESCRIPTION
## Summary
- export the Flask app instance as `flask_app` in `backend.__init__`
- update server launch script and tests to import from `backend` instead
- keep existing functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c2e49e51c832e8bcedbb01c7941fa