### PR TITLE
Load frontend libs via CDN and patch project updates

### DIFF
--- a/frontend/libs/babel.min.js
+++ b/frontend/libs/babel.min.js
@@ -1,1 +1,2 @@
-// Placeholder for Babel standalone. Replace with Babel Standalone.
+// Load Babel Standalone from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.23.9/babel.min.js"><\/script>');

--- a/frontend/libs/emotion-react.umd.min.js
+++ b/frontend/libs/emotion-react.umd.min.js
@@ -1,1 +1,2 @@
-// Placeholder for @emotion/react. Replace with full library.
+// Load Emotion React from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/@emotion/react@11.11.3/dist/emotion-react.umd.min.js"><\/script>');

--- a/frontend/libs/emotion-styled.umd.min.js
+++ b/frontend/libs/emotion-styled.umd.min.js
@@ -1,1 +1,2 @@
-// Placeholder for @emotion/styled. Replace with full library.
+// Load Emotion Styled from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js"><\/script>');

--- a/frontend/libs/material-ui.development.js
+++ b/frontend/libs/material-ui.development.js
@@ -1,1 +1,2 @@
-// Placeholder for MUI. Replace with Material UI 5 UMD build.
+// Load Material UI from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/@mui/material@5.15.15/umd/material-ui.development.js"><\/script>');

--- a/frontend/libs/react-dom.development.js
+++ b/frontend/libs/react-dom.development.js
@@ -1,1 +1,2 @@
-// Placeholder for ReactDOM library. Replace with full React DOM 18 build.
+// Load ReactDOM from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.development.js"><\/script>');

--- a/frontend/libs/react.development.js
+++ b/frontend/libs/react.development.js
@@ -1,1 +1,2 @@
-// Placeholder for React library. Replace with full React 18 build.
+// Load React from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.development.js"><\/script>');

--- a/frontend/libs/supabase.js
+++ b/frontend/libs/supabase.js
@@ -1,1 +1,2 @@
-// Placeholder for Supabase client. Replace with full supabase-js build.
+// Load Supabase client from CDN
+document.write('<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.js"><\/script>');

--- a/frontend/wireframe.js
+++ b/frontend/wireframe.js
@@ -99,8 +99,8 @@ function EditProject({ project, onClose }) {
   });
 
   const save = () => {
-    fetch(`/api/projects/${project.project_id}`, {
-      method: 'PUT',
+    fetch(`/api/project/${project.project_id}`, {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form),
     }).then(onClose);
@@ -411,8 +411,8 @@ function ProjectsPage() {
   };
 
   const saveEdit = (pid) => {
-    fetch(`/api/projects/${pid}`, {
-      method: 'PUT',
+    fetch(`/api/project/${pid}`, {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(editForm),
     }).then(() => {


### PR DESCRIPTION
## Summary
- Load React, ReactDOM, MUI, Emotion, Supabase and Babel from CDN instead of placeholders
- Use `PATCH /api/project/:id` for project update calls in the frontend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ebb351898832ebb3e4472156dd010