### PR TITLE
feat: expand project management capabilities

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from flask_cors import CORS
 
 from database import (
-    get_projects,
     get_review_tasks,
     update_review_task_assignee,
     get_users_list,
@@ -26,8 +25,7 @@ from database import (
     upsert_bep_section,
     update_bep_status,
     get_projects_full,
-    update_project_financials,
-    update_client_info,
+    update_project_record,
     insert_project_full,
     get_reference_options,
 )
@@ -40,9 +38,8 @@ CORS(app)
 @app.route('/api/projects', methods=['GET', 'POST'])
 def api_projects():
     if request.method == 'GET':
-        projects = get_projects()
-        data = [{'project_id': pid, 'project_name': name} for pid, name in projects]
-        return jsonify(data)
+        projects = get_projects_full()
+        return jsonify(projects)
 
     body = request.get_json() or {}
     if not body.get('project_name'):
@@ -157,20 +154,9 @@ def api_create_project():
 
 @app.route('/api/projects/<int:project_id>', methods=['PUT'])
 def api_update_full_project(project_id):
-    """Update financial and client details for a project."""
+    """Update project fields via a generic PUT."""
     data = request.get_json() or {}
-
-    update_project_financials(
-        project_id,
-        data.get('contract_value'),
-        data.get('payment_terms'),
-    )
-    update_client_info(
-        project_id,
-        data.get('client_contact'),
-        data.get('contact_email'),
-    )
-
+    update_project_record(project_id, data)
     return jsonify({'message': 'Project updated'})
 
 

--- a/database.py
+++ b/database.py
@@ -1323,6 +1323,28 @@ def insert_project_full(data):
         return False
     finally:
         conn.close()
+
+
+def update_project_record(project_id, data):
+    """Update arbitrary project fields for a given project_id."""
+    conn = connect_to_db()
+    if conn is None:
+        return False
+    try:
+        cursor = conn.cursor()
+        cols = [c for c in data.keys() if c]
+        if not cols:
+            return False
+        set_clause = ', '.join([f"{c} = ?" for c in cols])
+        sql = f"UPDATE projects SET {set_clause} WHERE project_id = ?"
+        cursor.execute(sql, [data[c] for c in cols] + [project_id])
+        conn.commit()
+        return True
+    except Exception as e:
+        print(f"❌ Error updating project: {e}")
+        return False
+    finally:
+        conn.close()
         
 if __name__ == "__main__":
     conn = connect_to_db()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ for mod in ["pyodbc"]:
 
 
 def test_get_projects_endpoint(monkeypatch):
-    monkeypatch.setattr('backend.app.get_projects', lambda: [(1, 'A')])
+    monkeypatch.setattr('backend.app.get_projects_full', lambda: [{'project_id': 1, 'project_name': 'A'}])
     client = app.test_client()
     resp = client.get('/api/projects')
     assert resp.status_code == 200
@@ -219,19 +219,14 @@ def test_projects_full(monkeypatch):
 def test_update_full_project(monkeypatch):
     called = {}
 
-    def fake_fin(pid, cv, pt):
-        called['fin'] = (pid, cv, pt)
+    def fake_update(pid, data):
+        called['args'] = (pid, data)
         return True
 
-    def fake_client(pid, cc, ce):
-        called['cli'] = (pid, cc, ce)
-        return True
-
-    monkeypatch.setattr('backend.app.update_project_financials', fake_fin)
-    monkeypatch.setattr('backend.app.update_client_info', fake_client)
+    monkeypatch.setattr('backend.app.update_project_record', fake_update)
     client = app.test_client()
     resp = client.put('/api/projects/5', json={'contract_value': 10})
     assert resp.status_code == 200
-    assert called['fin'] == (5, 10, None)
+    assert called['args'] == (5, {'contract_value': 10})
 
 


### PR DESCRIPTION
## Summary
- expose full project data on `/api/projects`
- support generic project updates via `update_project_record`
- add frontend Projects view with inline editing and new project form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1193a368832e9faf0b697812e7dd