### PR TITLE
chore: remove unused supabase references

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,6 @@
   <script src="libs/emotion-react.umd.min.js"></script>
   <script src="libs/emotion-styled.umd.min.js"></script>
   <script src="libs/material-ui.development.js"></script>
-  <script src="libs/supabase.js"></script>
   <script src="libs/babel.min.js"></script>
 </head>
 <body>

--- a/frontend/wireframe.js
+++ b/frontend/wireframe.js
@@ -19,11 +19,6 @@ const {
   Box,
   Button,
 } = MaterialUI;
-const { createClient } = supabase;
-// TODO: replace with your Supabase project credentials
-const supabaseUrl = 'https://your-project.supabase.co';
-const supabaseKey = 'public-anon-key';
-const supabaseClient = createClient(supabaseUrl, supabaseKey);
 // Fallback sample data used if the backend is not available
 const sampleProjects = [
   {


### PR DESCRIPTION
## Summary
- remove unused Supabase script tag from frontend index
- drop unused Supabase client setup from wireframe JS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fe1efda40832ea53ef16d5c3597b4