### PR TITLE
refactor: centralize schema definitions and SQL scripts

### DIFF
--- a/constants/schema.py
+++ b/constants/schema.py
@@ -1,0 +1,136 @@
+"""Database schema constants for tables and columns."""
+
+class Projects:
+    TABLE = "Projects"
+    ID = "project_id"
+    NAME = "project_name"
+    FOLDER_PATH = "folder_path"
+    IFC_FOLDER_PATH = "ifc_folder_path"
+    DATA_EXPORT_FOLDER = "data_export_folder"
+    START_DATE = "start_date"
+    END_DATE = "end_date"
+    STATUS = "status"
+    PRIORITY = "priority"
+    UPDATED_AT = "updated_at"
+
+class ReviewParameters:
+    TABLE = "ReviewParameters"
+    ID = "ParameterID"
+    PROJECT_ID = "ProjectID"
+    REVIEW_START_DATE = "ReviewStartDate"
+    NUMBER_OF_REVIEWS = "NumberOfReviews"
+    REVIEW_FREQUENCY = "ReviewFrequency"
+    LICENSE_START = "LicenseStartDate"
+    LICENSE_END = "LicenseEndDate"
+    CYCLE_ID = "cycle_id"
+
+class ReviewCycleDetails:
+    TABLE = "ReviewCycleDetails"
+    ID = "cycle_detail_id"
+    PROJECT_ID = "project_id"
+    CYCLE_ID = "cycle_id"
+    CONSTRUCTION_STAGE = "construction_stage"
+    PROPOSED_FEE = "proposed_fee"
+    ASSIGNED_USERS = "assigned_users"
+    REVIEWS_PER_PHASE = "reviews_per_phase"
+    PLANNED_START = "planned_start_date"
+    PLANNED_COMPLETION = "planned_completion_date"
+    ACTUAL_START = "actual_start_date"
+    ACTUAL_COMPLETION = "actual_completion_date"
+    HOLD_DATE = "hold_date"
+    RESUME_DATE = "resume_date"
+    NEW_CONTRACT = "new_contract"
+
+class ReviewSchedule:
+    TABLE = "ReviewSchedule"
+    ID = "schedule_id"
+    PROJECT_ID = "project_id"
+    CYCLE_ID = "cycle_id"
+    REVIEW_DATE = "review_date"
+    ASSIGNED_TO = "assigned_to"
+    STATUS = "status"
+    IS_BLOCKED = "is_blocked"
+    IS_WITHIN_LICENSE = "is_within_license_period"
+    MANUAL_OVERRIDE = "manual_override"
+
+class ProjectReviews:
+    TABLE = "project_reviews"
+    ID = "review_id"
+    PROJECT_ID = "project_id"
+    CYCLE_ID = "cycle_id"
+    SCOPED_REVIEWS = "scoped_reviews"
+    COMPLETED_REVIEWS = "completed_reviews"
+    LAST_UPDATED = "last_updated"
+
+class ACCImportFolders:
+    TABLE = "ACCImportFolders"
+    PROJECT_ID = "project_id"
+    ACC_FOLDER_PATH = "acc_folder_path"
+    LAST_IMPORT_DATE = "last_import_date"
+
+class ACCImportLogs:
+    TABLE = "ACCImportLogs"
+    ID = "log_id"
+    PROJECT_ID = "project_id"
+    FOLDER_NAME = "folder_name"
+    IMPORT_DATE = "import_date"
+    SUMMARY = "summary"
+
+class ACCDocs:
+    TABLE = "tblACCDocs"
+    ID = "id"
+    FILE_NAME = "file_name"
+    FILE_PATH = "file_path"
+    DATE_MODIFIED = "date_modified"
+    FILE_TYPE = "file_type"
+    FILE_SIZE_KB = "file_size_kb"
+    CREATED_AT = "created_at"
+    DELETED_AT = "deleted_at"
+    PROJECT_ID = "project_id"
+
+class Users:
+    TABLE = "users"
+    ID = "user_id"
+    NAME = "name"
+    ROLE = "role"
+    EMAIL = "email"
+
+class Tasks:
+    TABLE = "tasks"
+    ID = "task_id"
+    NAME = "task_name"
+    PROJECT_ID = "project_id"
+    CYCLE_ID = "cycle_id"
+    START_DATE = "start_date"
+    END_DATE = "end_date"
+    ASSIGNED_TO = "assigned_to"
+    DEPENDENCIES = "dependencies"
+    PROGRESS = "progress"
+
+class ContractualLinks:
+    TABLE = "ContractualLinks"
+    ID = "id"
+    PROJECT_ID = "project_id"
+    REVIEW_CYCLE_ID = "review_cycle_id"
+    BEP_CLAUSE = "bep_clause"
+    BILLING_EVENT = "billing_event"
+    AMOUNT_DUE = "amount_due"
+    STATUS = "status"
+
+class ReviewCycles:
+    TABLE = "review_cycles"
+    ID = "review_cycle_id"
+    PROJECT_ID = "project_id"
+    STAGE_ID = "stage_id"
+    START_DATE = "start_date"
+    END_DATE = "end_date"
+    NUM_REVIEWS = "num_reviews"
+    CREATED_BY = "created_by"
+
+class ReviewTasks:
+    TABLE = "review_tasks"
+    ID = "review_task_id"
+    SCHEDULE_ID = "schedule_id"
+    TASK_ID = "task_id"
+    ASSIGNED_TO = "assigned_to"
+    STATUS = "status"

--- a/sql/migrations/V001__initial_schema.sql
+++ b/sql/migrations/V001__initial_schema.sql
@@ -1,0 +1,14 @@
+-- V001: initial schema for BIM Project Management
+:r ../tables/create_projects.sql
+:r ../tables/create_review_parameters.sql
+:r ../tables/create_review_cycle_details.sql
+:r ../tables/create_review_schedule.sql
+:r ../tables/create_project_reviews.sql
+:r ../tables/create_accimportfolders.sql
+:r ../tables/create_accimportlogs.sql
+:r ../tables/create_tblaccdocs.sql
+:r ../tables/create_users.sql
+:r ../tables/create_tasks.sql
+:r ../tables/create_contractual_links.sql
+:r ../views/vw_review_schedule_details.sql
+GO

--- a/sql/tables/create_accimportfolders.sql
+++ b/sql/tables/create_accimportfolders.sql
@@ -1,0 +1,7 @@
+CREATE TABLE ACCImportFolders (
+    project_id INT PRIMARY KEY,
+    acc_folder_path NVARCHAR(1000) NOT NULL,
+    last_import_date DATETIME NULL,
+    CONSTRAINT FK_ACCImportFolders_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_accimportlogs.sql
+++ b/sql/tables/create_accimportlogs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE ACCImportLogs (
+    log_id INT IDENTITY(1,1) PRIMARY KEY,
+    project_id INT NOT NULL,
+    folder_name NVARCHAR(1000) NOT NULL,
+    import_date DATETIME DEFAULT GETDATE(),
+    summary NVARCHAR(MAX) NULL,
+    CONSTRAINT FK_ACCImportLogs_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_contractual_links.sql
+++ b/sql/tables/create_contractual_links.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ContractualLinks (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    project_id INT NOT NULL,
+    review_cycle_id INT NULL,
+    bep_clause NVARCHAR(255) NOT NULL,
+    billing_event NVARCHAR(255) NOT NULL,
+    amount_due DECIMAL(18,2) DEFAULT 0,
+    status NVARCHAR(50) DEFAULT 'Pending',
+    CONSTRAINT FK_ContractualLinks_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_project_reviews.sql
+++ b/sql/tables/create_project_reviews.sql
@@ -1,0 +1,10 @@
+CREATE TABLE project_reviews (
+    review_id INT IDENTITY(1,1) PRIMARY KEY,
+    project_id INT NOT NULL,
+    cycle_id INT NOT NULL,
+    scoped_reviews INT DEFAULT 0,
+    completed_reviews INT DEFAULT 0,
+    last_updated DATETIME DEFAULT GETDATE(),
+    CONSTRAINT FK_ProjectReviews_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_projects.sql
+++ b/sql/tables/create_projects.sql
@@ -1,0 +1,14 @@
+CREATE TABLE Projects (
+    project_id INT IDENTITY(1,1) PRIMARY KEY,
+    project_name NVARCHAR(510) NOT NULL,
+    folder_path NVARCHAR(1000) NULL,
+    ifc_folder_path NVARCHAR(1000) NULL,
+    data_export_folder NVARCHAR(1000) NULL,
+    start_date DATE NULL,
+    end_date DATE NULL,
+    status NVARCHAR(100) NULL,
+    priority NVARCHAR(100) NULL,
+    created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME NULL
+);
+GO

--- a/sql/tables/create_review_cycle_details.sql
+++ b/sql/tables/create_review_cycle_details.sql
@@ -1,0 +1,20 @@
+CREATE TABLE ReviewCycleDetails (
+    cycle_detail_id INT IDENTITY(1,1) PRIMARY KEY,
+    project_id INT NOT NULL,
+    cycle_id INT NOT NULL,
+    construction_stage NVARCHAR(200) NULL,
+    proposed_fee DECIMAL(18,2) NULL,
+    assigned_users NVARCHAR(255) NULL,
+    reviews_per_phase INT NULL,
+    planned_start_date DATE NULL,
+    planned_completion_date DATE NULL,
+    actual_start_date DATE NULL,
+    actual_completion_date DATE NULL,
+    hold_date DATE NULL,
+    resume_date DATE NULL,
+    new_contract BIT DEFAULT 0,
+    last_updated DATETIME DEFAULT GETDATE(),
+    CONSTRAINT FK_ReviewCycleDetails_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id),
+    CONSTRAINT FK_ReviewCycleDetails_Parameters FOREIGN KEY (cycle_id, project_id) REFERENCES ReviewParameters(cycle_id, ProjectID)
+);
+GO

--- a/sql/tables/create_review_parameters.sql
+++ b/sql/tables/create_review_parameters.sql
@@ -1,0 +1,12 @@
+CREATE TABLE ReviewParameters (
+    ParameterID INT IDENTITY(1,1) PRIMARY KEY,
+    ProjectID INT NOT NULL,
+    ReviewStartDate DATE NOT NULL,
+    NumberOfReviews INT NOT NULL,
+    ReviewFrequency INT NOT NULL,
+    LicenseStartDate DATE NULL,
+    LicenseEndDate DATE NULL,
+    cycle_id INT NOT NULL,
+    CONSTRAINT FK_ReviewParameters_Projects FOREIGN KEY (ProjectID) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_review_schedule.sql
+++ b/sql/tables/create_review_schedule.sql
@@ -1,0 +1,15 @@
+CREATE TABLE ReviewSchedule (
+    schedule_id INT IDENTITY(1,1) PRIMARY KEY,
+    project_id INT NOT NULL,
+    cycle_id INT NOT NULL,
+    review_date DATE NOT NULL,
+    assigned_to INT NULL,
+    status NVARCHAR(100) NULL,
+    is_blocked BIT DEFAULT 0,
+    is_within_license_period BIT DEFAULT 1,
+    manual_override BIT DEFAULT 0,
+    CONSTRAINT FK_ReviewSchedule_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id),
+    CONSTRAINT FK_ReviewSchedule_Parameters FOREIGN KEY (cycle_id, project_id) REFERENCES ReviewParameters(cycle_id, ProjectID),
+    CONSTRAINT FK_ReviewSchedule_Users FOREIGN KEY (assigned_to) REFERENCES users(user_id)
+);
+GO

--- a/sql/tables/create_tasks.sql
+++ b/sql/tables/create_tasks.sql
@@ -1,0 +1,16 @@
+CREATE TABLE tasks (
+    task_id INT IDENTITY(1,1) PRIMARY KEY,
+    task_name NVARCHAR(510) NOT NULL,
+    project_id INT NOT NULL,
+    cycle_id INT NOT NULL,
+    start_date DATE NULL,
+    end_date DATE NULL,
+    assigned_to INT NULL,
+    dependencies NVARCHAR(510) NULL,
+    progress DECIMAL(5,2) DEFAULT 0,
+    created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME NULL,
+    CONSTRAINT FK_Tasks_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id),
+    CONSTRAINT FK_Tasks_Users FOREIGN KEY (assigned_to) REFERENCES users(user_id)
+);
+GO

--- a/sql/tables/create_tblaccdocs.sql
+++ b/sql/tables/create_tblaccdocs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tblACCDocs (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    file_name NVARCHAR(510) NOT NULL,
+    file_path NVARCHAR(MAX) NOT NULL,
+    date_modified DATETIME NULL,
+    file_type NVARCHAR(100) NULL,
+    file_size_kb FLOAT NULL,
+    created_at DATETIME DEFAULT GETDATE(),
+    deleted_at DATETIME NULL,
+    project_id INT NOT NULL,
+    CONSTRAINT FK_tblACCDocs_Projects FOREIGN KEY (project_id) REFERENCES Projects(project_id)
+);
+GO

--- a/sql/tables/create_users.sql
+++ b/sql/tables/create_users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE users (
+    user_id INT IDENTITY(1,1) PRIMARY KEY,
+    name NVARCHAR(510) NOT NULL,
+    role NVARCHAR(100) NULL,
+    email NVARCHAR(510) NOT NULL UNIQUE,
+    created_at DATETIME DEFAULT GETDATE()
+);
+GO

--- a/sql/views/vw_review_schedule_details.sql
+++ b/sql/views/vw_review_schedule_details.sql
@@ -1,0 +1,24 @@
+CREATE VIEW vw_ReviewScheduleDetails AS
+SELECT
+    rs.schedule_id,
+    rs.review_date,
+    rs.cycle_id,
+    rs.project_id,
+    p.project_name,
+    d.construction_stage,
+    d.proposed_fee,
+    d.assigned_users,
+    d.reviews_per_phase,
+    d.planned_start_date,
+    d.planned_completion_date,
+    d.actual_start_date,
+    d.actual_completion_date,
+    d.hold_date,
+    d.resume_date,
+    d.new_contract,
+    rs.assigned_to,
+    rs.status
+FROM ReviewSchedule rs
+JOIN Projects p ON rs.project_id = p.project_id
+LEFT JOIN ReviewCycleDetails d ON rs.project_id = d.project_id AND rs.cycle_id = d.cycle_id;
+GO

--- a/tasks_users_ui.py
+++ b/tasks_users_ui.py
@@ -1,10 +1,11 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from database import connect_to_db, get_projects, get_cycle_ids, fetch_data
+from constants import schema as S
 
 # Function to fetch users for dropdown
 def get_users():
-    users = fetch_data("SELECT name FROM users")
+    users = fetch_data(f"SELECT {S.Users.NAME} FROM {S.Users.TABLE}")
     return [user[0] for user in users]
 
 # Function to add a user
@@ -17,13 +18,19 @@ def add_user(name, role, email):
         cursor = conn.cursor()
         
         # Check if email already exists
-        cursor.execute("SELECT COUNT(*) FROM users WHERE email = ?", (email,))
+        cursor.execute(
+            f"SELECT COUNT(*) FROM {S.Users.TABLE} WHERE {S.Users.EMAIL} = ?",
+            (email,),
+        )
         if cursor.fetchone()[0] > 0:
             messagebox.showerror("Error", "This email is already registered!")
             return
 
         # Insert new user if email is unique
-        cursor.execute("INSERT INTO users (name, role, email) VALUES (?, ?, ?)", (name, role, email))
+        cursor.execute(
+            f"INSERT INTO {S.Users.TABLE} ({S.Users.NAME}, {S.Users.ROLE}, {S.Users.EMAIL}) VALUES (?, ?, ?)",
+            (name, role, email),
+        )
         conn.commit()
         messagebox.showinfo("Success", "User added successfully!")
     
@@ -166,7 +173,7 @@ def main():
         try:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT task_name, start_date, end_date, assigned_to FROM tasks WHERE project_id = ? AND cycle_id = ?",
+                f"SELECT {S.Tasks.NAME}, {S.Tasks.START_DATE}, {S.Tasks.END_DATE}, {S.Tasks.ASSIGNED_TO} FROM {S.Tasks.TABLE} WHERE {S.Tasks.PROJECT_ID} = ? AND {S.Tasks.CYCLE_ID} = ?",
                 (pid, cid),
             )
             rows = cursor.fetchall()
@@ -184,7 +191,7 @@ def main():
         try:
             cursor = conn.cursor()
             cursor.execute(
-                "INSERT INTO tasks (task_name, project_id, cycle_id, start_date, end_date, assigned_to) VALUES (?, ?, ?, ?, ?, ?)",
+                f"INSERT INTO {S.Tasks.TABLE} ({S.Tasks.NAME}, {S.Tasks.PROJECT_ID}, {S.Tasks.CYCLE_ID}, {S.Tasks.START_DATE}, {S.Tasks.END_DATE}, {S.Tasks.ASSIGNED_TO}) VALUES (?, ?, ?, ?, ?, ?)",
                 (task_name, project_id, cycle_id, start_date, end_date, assigned_to),
             )
             conn.commit()


### PR DESCRIPTION
## Summary
- add dedicated SQL table and view definitions with migration entry
- consolidate database table/column names in `constants/schema.py`
- update DB helpers and UI utilities to use schema constants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901bd07ee8832eab192b4cdeedca96