### PR TITLE
Fix project insertion typing and review constants

### DIFF
--- a/constants/schema.py
+++ b/constants/schema.py
@@ -490,13 +490,13 @@ class ContractualLinks:
 
 class ReviewParameters:
     TABLE = "ReviewParameters"
-    PARAMETERID = "ParameterID"
-    PROJECTID = "ProjectID"
-    REVIEWSTARTDATE = "ReviewStartDate"
-    NUMBEROFREVIEWS = "NumberOfReviews"
-    REVIEWFREQUENCY = "ReviewFrequency"
-    LICENSESTARTDATE = "LicenseStartDate"
-    LICENSEENDDATE = "LicenseEndDate"
+    PARAMETER_ID = "ParameterID"
+    PROJECT_ID = "ProjectID"
+    REVIEW_START_DATE = "ReviewStartDate"
+    NUMBER_OF_REVIEWS = "NumberOfReviews"
+    REVIEW_FREQUENCY = "ReviewFrequency"
+    LICENSE_START = "LicenseStartDate"
+    LICENSE_END = "LicenseEndDate"
     CYCLE_ID = "cycle_id"
 
 class StageReviewPlan:


### PR DESCRIPTION
## Summary
- ensure numeric fields are cast before project insertion to avoid SQL type errors
- define ReviewParameters constant names used by data access layer

## Testing
- `pytest -q` *(fails: No module named 'pyparsing')*

------
https://chatgpt.com/codex/tasks/task_e_68918a23b360832ea2a40946d3aca81f